### PR TITLE
Refactored outlier detector in preparation for MetricPoint tags fix.

### DIFF
--- a/core/src/main/java/com/expedia/adaptivealerting/core/detector/AbstractOutlierDetector.java
+++ b/core/src/main/java/com/expedia/adaptivealerting/core/detector/AbstractOutlierDetector.java
@@ -15,8 +15,6 @@
  */
 package com.expedia.adaptivealerting.core.detector;
 
-import com.expedia.adaptivealerting.core.OutlierDetector;
-import com.expedia.adaptivealerting.core.OutlierLevel;
 import com.expedia.www.haystack.commons.entities.MetricPoint;
 import scala.collection.immutable.Map;
 
@@ -27,11 +25,11 @@ public abstract class AbstractOutlierDetector implements OutlierDetector {
     protected MetricPoint tag(
             MetricPoint metricPoint,
             OutlierLevel outlierLevel,
-            Float prediction,
-            Float upperThresholdStrong,
-            Float upperThresholdWeak,
-            Float lowerThresholdStrong,
-            Float lowerThresholdWeak) {
+            Double prediction,
+            Double weakThresholdUpper,
+            Double weakThresholdLower,
+            Double strongThresholdUpper,
+            Double strongThresholdLower) {
     
         Map tags = metricPoint.tags();
         
@@ -39,19 +37,19 @@ public abstract class AbstractOutlierDetector implements OutlierDetector {
             tags = tags.updated(OUTLIER_LEVEL, outlierLevel.name());
         }
         if (prediction != null) {
-            tags = tags.updated(PREDICTION, prediction);
+            tags = tags.updated(PREDICTION, prediction.floatValue());
         }
-        if (upperThresholdStrong != null) {
-            tags = tags.updated(STRONG_THRESHOLD_UPPER, upperThresholdStrong);
+        if (weakThresholdUpper != null) {
+            tags = tags.updated(WEAK_THRESHOLD_UPPER, weakThresholdUpper.floatValue());
         }
-        if (upperThresholdWeak != null) {
-            tags = tags.updated(WEAK_THRESHOLD_UPPER, upperThresholdWeak);
+        if (weakThresholdLower != null) {
+            tags = tags.updated(WEAK_THRESHOLD_LOWER, weakThresholdLower.floatValue());
         }
-        if (lowerThresholdStrong != null) {
-            tags = tags.updated(STRONG_THRESHOLD_LOWER, lowerThresholdStrong);
+        if (strongThresholdUpper != null) {
+            tags = tags.updated(STRONG_THRESHOLD_UPPER, strongThresholdUpper.floatValue());
         }
-        if (lowerThresholdWeak != null) {
-            tags = tags.updated(WEAK_THRESHOLD_LOWER, lowerThresholdWeak);
+        if (strongThresholdLower != null) {
+            tags = tags.updated(STRONG_THRESHOLD_LOWER, strongThresholdLower.floatValue());
         }
     
         return new MetricPoint(

--- a/core/src/main/java/com/expedia/adaptivealerting/core/detector/OutlierDetector.java
+++ b/core/src/main/java/com/expedia/adaptivealerting/core/detector/OutlierDetector.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.expedia.adaptivealerting.core;
+package com.expedia.adaptivealerting.core.detector;
 
 import com.expedia.www.haystack.commons.entities.MetricPoint;
 
@@ -28,7 +28,20 @@ public interface OutlierDetector {
      * Classifies the given metric point.
      *
      * @param metricPoint Metric point.
-     * @return A new copy of the metric point, with classification and additional information attached.
+     * @return Outlier classification result, with supporting data such as the prediction, outlier score and various
+     * thresholds.
      */
-    MetricPoint classify(MetricPoint metricPoint);
+    OutlierDetectorResult classify(MetricPoint metricPoint);
+    
+    /**
+     * Classifies the given metric point, and enriches it with the classification.
+     *
+     * @param metricPoint Metric point.
+     * @return A new copy of the metric point, with classification and additional information attached.
+     * @deprecated It is incorrect to add the outlier classification result and supporting data to the metric point as
+     * tags. Metric 2.0 tags are intended to identify the metric itself, not the metric values. Use
+     * {@link #classify(MetricPoint)} instead.
+     */
+    @Deprecated
+    MetricPoint classifyAndEnrich(MetricPoint metricPoint);
 }

--- a/core/src/main/java/com/expedia/adaptivealerting/core/detector/OutlierDetectorResult.java
+++ b/core/src/main/java/com/expedia/adaptivealerting/core/detector/OutlierDetectorResult.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.core.detector;
+
+/**
+ * Outlier detector result.
+ *
+ * @author Willie Wheeler
+ */
+public class OutlierDetectorResult {
+    private Long epochSecond;
+    private Double observed;
+    private Double predicted;
+    private Double weakThresholdUpper;
+    private Double weakThresholdLower;
+    private Double strongThresholdUpper;
+    private Double strongThresholdLower;
+    private Double outlierScore;
+    private OutlierLevel outlierLevel;
+    
+    public Long getEpochSecond() {
+        return epochSecond;
+    }
+    
+    public void setEpochSecond(Long epochSecond) {
+        this.epochSecond = epochSecond;
+    }
+    
+    public Double getObserved() {
+        return observed;
+    }
+    
+    public void setObserved(Double observed) {
+        this.observed = observed;
+    }
+    
+    public Double getPredicted() {
+        return predicted;
+    }
+    
+    public void setPredicted(Double predicted) {
+        this.predicted = predicted;
+    }
+    
+    public Double getWeakThresholdUpper() {
+        return weakThresholdUpper;
+    }
+    
+    public void setWeakThresholdUpper(Double weakThresholdUpper) {
+        this.weakThresholdUpper = weakThresholdUpper;
+    }
+    
+    public Double getWeakThresholdLower() {
+        return weakThresholdLower;
+    }
+    
+    public void setWeakThresholdLower(Double weakThresholdLower) {
+        this.weakThresholdLower = weakThresholdLower;
+    }
+    
+    public Double getStrongThresholdUpper() {
+        return strongThresholdUpper;
+    }
+    
+    public void setStrongThresholdUpper(Double strongThresholdUpper) {
+        this.strongThresholdUpper = strongThresholdUpper;
+    }
+    
+    public Double getStrongThresholdLower() {
+        return strongThresholdLower;
+    }
+    
+    public void setStrongThresholdLower(Double strongThresholdLower) {
+        this.strongThresholdLower = strongThresholdLower;
+    }
+    
+    public Double getOutlierScore() {
+        return outlierScore;
+    }
+    
+    public void setOutlierScore(Double outlierScore) {
+        this.outlierScore = outlierScore;
+    }
+    
+    public OutlierLevel getOutlierLevel() {
+        return outlierLevel;
+    }
+    
+    public void setOutlierLevel(OutlierLevel outlierLevel) {
+        this.outlierLevel = outlierLevel;
+    }
+}

--- a/core/src/main/java/com/expedia/adaptivealerting/core/detector/OutlierLevel.java
+++ b/core/src/main/java/com/expedia/adaptivealerting/core/detector/OutlierLevel.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.expedia.adaptivealerting.core;
+package com.expedia.adaptivealerting.core.detector;
 
 /**
  * Outlier level enum.

--- a/core/src/main/java/com/expedia/adaptivealerting/core/util/MetricPointUtil.java
+++ b/core/src/main/java/com/expedia/adaptivealerting/core/util/MetricPointUtil.java
@@ -15,7 +15,7 @@
  */
 package com.expedia.adaptivealerting.core.util;
 
-import com.expedia.adaptivealerting.core.OutlierLevel;
+import com.expedia.adaptivealerting.core.detector.OutlierLevel;
 import com.expedia.www.haystack.commons.entities.MetricPoint;
 import com.expedia.www.haystack.commons.entities.MetricType;
 import scala.Enumeration;

--- a/core/src/test/java/com/expedia/adaptivealerting/core/detector/ConstantThresholdOutlierDetectorTest.java
+++ b/core/src/test/java/com/expedia/adaptivealerting/core/detector/ConstantThresholdOutlierDetectorTest.java
@@ -16,16 +16,14 @@
 
 package com.expedia.adaptivealerting.core.detector;
 
-import com.expedia.adaptivealerting.core.OutlierDetector;
-import com.expedia.adaptivealerting.core.OutlierLevel;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Instant;
 
-import static com.expedia.adaptivealerting.core.OutlierLevel.NORMAL;
-import static com.expedia.adaptivealerting.core.OutlierLevel.STRONG;
-import static com.expedia.adaptivealerting.core.OutlierLevel.WEAK;
+import static com.expedia.adaptivealerting.core.detector.OutlierLevel.NORMAL;
+import static com.expedia.adaptivealerting.core.detector.OutlierLevel.STRONG;
+import static com.expedia.adaptivealerting.core.detector.OutlierLevel.WEAK;
 import static com.expedia.adaptivealerting.core.detector.ConstantThresholdOutlierDetector.LEFT_TAILED;
 import static com.expedia.adaptivealerting.core.detector.ConstantThresholdOutlierDetector.RIGHT_TAILED;
 import static com.expedia.adaptivealerting.core.util.MetricPointUtil.metricPoint;
@@ -45,30 +43,30 @@ public class ConstantThresholdOutlierDetectorTest {
     
     @Test(expected = IllegalArgumentException.class)
     public void testValidateTail() {
-        new ConstantThresholdOutlierDetector(-1, 1.0f, 0.0f);
+        new ConstantThresholdOutlierDetector(-1, 1.0, 0.0);
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void testValidateLeftTailedThresholds() {
-        new ConstantThresholdOutlierDetector(LEFT_TAILED, 30.0f, 10.0f);
+        new ConstantThresholdOutlierDetector(LEFT_TAILED, 30.0, 10.0);
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void testValidateRightTailedThresholds() {
-        new ConstantThresholdOutlierDetector(RIGHT_TAILED, 10.0f, 30.0f);
+        new ConstantThresholdOutlierDetector(RIGHT_TAILED, 10.0, 30.0);
     }
     
     @Test
     public void testAccessors() {
-        ConstantThresholdOutlierDetector detector = new ConstantThresholdOutlierDetector(RIGHT_TAILED, 60.0f, 30.0f);
+        ConstantThresholdOutlierDetector detector = new ConstantThresholdOutlierDetector(RIGHT_TAILED, 60.0, 30.0);
         assertEquals(RIGHT_TAILED, detector.getTail());
-        assertEquals(30.0f, detector.getWeakThreshold());
-        assertEquals(60.0f, detector.getStrongThreshold());
+        assertEquals(30.0, detector.getWeakThreshold());
+        assertEquals(60.0, detector.getStrongThreshold());
     }
     
     @Test
     public void testEvaluateLeftTailed_positiveThresholds() {
-        ConstantThresholdOutlierDetector detector = new ConstantThresholdOutlierDetector(LEFT_TAILED, 100.0f, 300.0f);
+        ConstantThresholdOutlierDetector detector = new ConstantThresholdOutlierDetector(LEFT_TAILED, 100.0, 300.0);
         assertEquals(NORMAL, level(detector, instant, 500.0f));
         assertEquals(WEAK, level(detector, instant, 300.0f));
         assertEquals(WEAK, level(detector, instant, 200.0f));
@@ -78,7 +76,7 @@ public class ConstantThresholdOutlierDetectorTest {
     
     @Test
     public void testEvaluateLeftTailed_negativeThresholds() {
-        ConstantThresholdOutlierDetector detector = new ConstantThresholdOutlierDetector(LEFT_TAILED, -30.0f, -10.0f);
+        ConstantThresholdOutlierDetector detector = new ConstantThresholdOutlierDetector(LEFT_TAILED, -30.0, -10.0);
         assertEquals(NORMAL, level(detector, instant, 1.0f));
         assertEquals(WEAK, level(detector, instant, -10.0f));
         assertEquals(WEAK, level(detector, instant, -15.0f));
@@ -88,7 +86,7 @@ public class ConstantThresholdOutlierDetectorTest {
     
     @Test
     public void testEvaluateRightTailed_positiveThresholds() {
-        ConstantThresholdOutlierDetector detector = new ConstantThresholdOutlierDetector(RIGHT_TAILED, 300.0f, 200.0f);
+        ConstantThresholdOutlierDetector detector = new ConstantThresholdOutlierDetector(RIGHT_TAILED, 300.0, 200.0);
         assertEquals(NORMAL, level(detector, instant, 100.0f));
         assertEquals(WEAK, level(detector, instant, 200.0f));
         assertEquals(WEAK, level(detector, instant, 220.0f));
@@ -98,8 +96,7 @@ public class ConstantThresholdOutlierDetectorTest {
     
     @Test
     public void testEvaluateRightTailed_negativeThresholds() {
-        ConstantThresholdOutlierDetector detector =
-                new ConstantThresholdOutlierDetector(RIGHT_TAILED, -100.0f, -300.0f);
+        ConstantThresholdOutlierDetector detector = new ConstantThresholdOutlierDetector(RIGHT_TAILED, -100.0, -300.0);
         assertEquals(NORMAL, level(detector, instant, -1000.0f));
         assertEquals(WEAK, level(detector, instant, -300.0f));
         assertEquals(WEAK, level(detector, instant, -250.0f));
@@ -108,6 +105,6 @@ public class ConstantThresholdOutlierDetectorTest {
     }
     
     private OutlierLevel level(OutlierDetector detector, Instant instant, float value) {
-        return outlierLevel(detector.classify(metricPoint(instant, value)));
+        return outlierLevel(detector.classifyAndEnrich(metricPoint(instant, value)));
     }
 }

--- a/core/src/test/java/com/expedia/adaptivealerting/core/detector/EwmaOutlierDetectorTest.java
+++ b/core/src/test/java/com/expedia/adaptivealerting/core/detector/EwmaOutlierDetectorTest.java
@@ -85,7 +85,7 @@ public class EwmaOutlierDetectorTest {
             
             // This detector doesn't currently do anything with the instant, so we can just pass now().
             // This may change in the future.
-            detector.classify(metricPoint(Instant.now(), observed));
+            detector.classifyAndEnrich(metricPoint(Instant.now(), observed));
             
             assertApproxEqual(testRow.getKnownMean(), testRow.getMean());
             assertApproxEqual(testRow.getMean(), detector.getMean());

--- a/core/src/test/java/com/expedia/adaptivealerting/core/detector/PewmaOutlierDetectorTest.java
+++ b/core/src/test/java/com/expedia/adaptivealerting/core/detector/PewmaOutlierDetectorTest.java
@@ -15,7 +15,6 @@
  */
 package com.expedia.adaptivealerting.core.detector;
 
-import com.expedia.adaptivealerting.core.OutlierLevel;
 import com.expedia.www.haystack.commons.entities.MetricPoint;
 import com.opencsv.CSVReader;
 import com.opencsv.bean.CsvToBeanBuilder;
@@ -70,8 +69,8 @@ public class PewmaOutlierDetectorTest {
             assertApproxEqual(ewmaOutlierDetector.getMean(), pewmaOutlierDetector.getMean(), threshold);
             assertApproxEqual(ewmaStdDev, pewmaOutlierDetector.getStdDev(), threshold);
             
-            final MetricPoint pewmaResult = pewmaOutlierDetector.classify(metricPoint(Instant.now(), value));
-            final MetricPoint ewmaResult = ewmaOutlierDetector.classify(metricPoint(Instant.now(), value));
+            final MetricPoint pewmaResult = pewmaOutlierDetector.classifyAndEnrich(metricPoint(Instant.now(), value));
+            final MetricPoint ewmaResult = ewmaOutlierDetector.classifyAndEnrich(metricPoint(Instant.now(), value));
             
             OutlierLevel pOL = outlierLevel(pewmaResult);
             OutlierLevel eOL = outlierLevel(ewmaResult);
@@ -98,7 +97,7 @@ public class PewmaOutlierDetectorTest {
 
             // This detector doesn't currently do anything with the instant, so we can just pass now().
             // This may change in the future.
-            final MetricPoint result = detector.classify(metricPoint(Instant.now(), (float) observed));
+            final MetricPoint result = detector.classifyAndEnrich(metricPoint(Instant.now(), (float) observed));
             
             final OutlierLevel level = outlierLevel(result);
             assertApproxEqual(testRow.getMean(), detector.getMean(), 0.00001);

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/util/DetectorUtil.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/util/DetectorUtil.java
@@ -15,7 +15,7 @@
  */
 package com.expedia.adaptivealerting.kafka.util;
 
-import com.expedia.adaptivealerting.core.OutlierDetector;
+import com.expedia.adaptivealerting.core.detector.OutlierDetector;
 import com.expedia.www.haystack.commons.entities.MetricPoint;
 import com.expedia.www.haystack.commons.entities.MetricType;
 import com.expedia.www.haystack.commons.entities.encoders.Encoder;
@@ -92,7 +92,7 @@ public class DetectorUtil {
         }
 
         final OutlierDetector detector = detectors.get(metricId);
-        return detector.classify(metricPoint);
+        return detector.classifyAndEnrich(metricPoint);
     }
 
     static String extractMetricId(MetricPoint metricPoint) {

--- a/kafka/src/test/java/com/expedia/adaptivealerting/kafka/util/DetectorUtilTest.java
+++ b/kafka/src/test/java/com/expedia/adaptivealerting/kafka/util/DetectorUtilTest.java
@@ -15,7 +15,7 @@
  */
 package com.expedia.adaptivealerting.kafka.util;
 
-import com.expedia.adaptivealerting.core.OutlierDetector;
+import com.expedia.adaptivealerting.core.detector.OutlierDetector;
 import com.expedia.adaptivealerting.core.detector.ConstantThresholdOutlierDetector;
 import com.expedia.www.haystack.commons.entities.MetricPoint;
 import com.expedia.www.haystack.commons.entities.MetricType;

--- a/tools/src/main/java/com/expedia/adaptivealerting/tools/pipeline/filter/OutlierDetectorMetricFilter.java
+++ b/tools/src/main/java/com/expedia/adaptivealerting/tools/pipeline/filter/OutlierDetectorMetricFilter.java
@@ -15,7 +15,7 @@
  */
 package com.expedia.adaptivealerting.tools.pipeline.filter;
 
-import com.expedia.adaptivealerting.core.OutlierDetector;
+import com.expedia.adaptivealerting.core.detector.OutlierDetector;
 import com.expedia.www.haystack.commons.entities.MetricPoint;
 
 import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
@@ -36,6 +36,6 @@ public final class OutlierDetectorMetricFilter extends AbstractMetricFilter {
     @Override
     public void next(MetricPoint metricPoint) {
         notNull(metricPoint, "metricPoint can't be null");
-        publish(outlierDetector.classify(metricPoint));
+        publish(outlierDetector.classifyAndEnrich(metricPoint));
     }
 }

--- a/tools/src/main/java/com/expedia/adaptivealerting/tools/pipeline/sink/ChartSink.java
+++ b/tools/src/main/java/com/expedia/adaptivealerting/tools/pipeline/sink/ChartSink.java
@@ -15,15 +15,15 @@
  */
 package com.expedia.adaptivealerting.tools.pipeline.sink;
 
-import com.expedia.adaptivealerting.core.OutlierLevel;
+import com.expedia.adaptivealerting.core.detector.OutlierLevel;
 import com.expedia.adaptivealerting.tools.pipeline.MetricSink;
 import com.expedia.adaptivealerting.tools.visualization.ChartSeries;
 import com.expedia.www.haystack.commons.entities.MetricPoint;
 import org.jfree.data.time.Second;
 import org.jfree.data.time.TimeSeries;
 
-import static com.expedia.adaptivealerting.core.OutlierLevel.STRONG;
-import static com.expedia.adaptivealerting.core.OutlierLevel.WEAK;
+import static com.expedia.adaptivealerting.core.detector.OutlierLevel.STRONG;
+import static com.expedia.adaptivealerting.core.detector.OutlierLevel.WEAK;
 import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
 import static com.expedia.adaptivealerting.core.util.MetricPointTags.*;
 import static com.expedia.adaptivealerting.core.util.MetricPointUtil.outlierLevel;


### PR DESCRIPTION
I mistakenly used MetricPoint tags as a mechanism for shuttling outlier
detection results around the data pipeline (tools module). This was a
mistake: MetricPoint tags are for uniquely identifying the metric and not
for carrying metric values around.

Therefore I've updated the OutlierDetector interface so to add a
classify()  method that returns just the classification result, instead of
returning a whole MetricPoint with abused tags. The old classify() method
is still there, but I've renamed it to classifyAndEnrich() and retrofitted
it to use the new classify() method. In later commits I'll correct the
mistake and eventually remove the classifyAndEnrich() method altogether.