### PR TITLE
This includes following changes

### DIFF
--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -35,6 +35,11 @@
     <description>Anomaly detection for streaming time series.</description>
     <url>https://github.com/ExpediaDotCom/haystack-adaptive-alerting</url>
 
+    <properties>
+        <maven-scalatest-plugin.version>1.0</maven-scalatest-plugin.version>
+        <maven-scala-plugin.version>3.2.1</maven-scala-plugin.version>
+    </properties>
+
     <dependencies>
 
         <!-- Haystack -->
@@ -76,9 +81,60 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_${scala.major.minor.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.pegdown</groupId>
+            <artifactId>pegdown</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams</artifactId>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${scala.major.minor.version}</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${scala.major.minor.version}</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
+        <testSourceDirectory>src/test/scala</testSourceDirectory>
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
@@ -95,6 +151,41 @@
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>${maven-scala-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>scala-compile-first</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>scala-test-compile</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.scalatest</groupId>
+                <artifactId>scalatest-maven-plugin</artifactId>
+                <version>${maven-scalatest-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/ConstantThresholdOutlierDetectorStreamRunnerBuilder.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/ConstantThresholdOutlierDetectorStreamRunnerBuilder.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.kafka.detector;
+
+import com.expedia.adaptivealerting.anomdetect.ConstantThresholdAnomalyDetector;
+import com.expedia.adaptivealerting.kafka.util.AppUtil;
+import com.expedia.adaptivealerting.kafka.util.DetectorUtil;
+import com.expedia.adaptivealerting.kafka.util.StreamRunnerBuilder;
+import com.expedia.www.haystack.commons.kstreams.app.StreamsRunner;
+import com.typesafe.config.Config;
+import org.apache.kafka.streams.StreamsBuilder;
+
+import static com.expedia.adaptivealerting.anomdetect.ConstantThresholdAnomalyDetector.RIGHT_TAILED;
+
+public class ConstantThresholdOutlierDetectorStreamRunnerBuilder implements StreamRunnerBuilder {
+  @Override
+  public StreamsRunner build(Config appConfig) {
+    final StreamsBuilder builder = DetectorUtil.createDetectorStreamsBuilder(
+            appConfig.getString("topic"),
+            id -> new ConstantThresholdAnomalyDetector(RIGHT_TAILED, 0.99f, 0.95f)
+    );
+
+    return AppUtil.createStreamsRunner(appConfig, builder);
+  }
+}

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/EwmaOutlierDetectorStreamRunnerBuilder.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/EwmaOutlierDetectorStreamRunnerBuilder.java
@@ -15,13 +15,21 @@
  */
 package com.expedia.adaptivealerting.kafka.detector;
 
+import com.expedia.adaptivealerting.anomdetect.EwmaAnomalyDetector;
 import com.expedia.adaptivealerting.kafka.util.AppUtil;
+import com.expedia.adaptivealerting.kafka.util.DetectorUtil;
+import com.expedia.adaptivealerting.kafka.util.StreamRunnerBuilder;
+import com.expedia.www.haystack.commons.kstreams.app.StreamsRunner;
 import com.typesafe.config.Config;
+import org.apache.kafka.streams.StreamsBuilder;
 
-public class KafkaConstantThresholdOutlierDetector {
-
-    public static void main(String[] args) {
-        Config appConfig = AppUtil.getAppConfig("constant-detector");
-        AppUtil.launchStreamRunner(new ConstantThresholdOutlierDetectorStreamRunnerBuilder().build(appConfig));
-    }
+public class EwmaOutlierDetectorStreamRunnerBuilder implements StreamRunnerBuilder {
+  @Override
+  public StreamsRunner build(Config appConfig) {
+    final StreamsBuilder builder = DetectorUtil.createDetectorStreamsBuilder(
+            appConfig.getString("topic"),
+            id -> new EwmaAnomalyDetector(0.8, 3.0, 2.0, 100.0)
+    );
+    return AppUtil.createStreamsRunner(appConfig, builder);
+  }
 }

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaEwmaOutlierDetector.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaEwmaOutlierDetector.java
@@ -15,12 +15,8 @@
  */
 package com.expedia.adaptivealerting.kafka.detector;
 
-import com.expedia.adaptivealerting.anomdetect.EwmaAnomalyDetector;
 import com.expedia.adaptivealerting.kafka.util.AppUtil;
-import com.expedia.adaptivealerting.kafka.util.DetectorUtil;
-import com.expedia.www.haystack.commons.kstreams.app.StreamsRunner;
 import com.typesafe.config.Config;
-import org.apache.kafka.streams.StreamsBuilder;
 
 /**
  * Kafka Streams application for the EWMA outlier detector.
@@ -31,13 +27,6 @@ public class KafkaEwmaOutlierDetector {
     
     public static void main(String[] args) {
         Config appConfig = AppUtil.getAppConfig("ewma-detector");
-
-        final StreamsBuilder builder = DetectorUtil.createDetectorStreamsBuilder(
-                appConfig.getString("topic"),
-                id -> new EwmaAnomalyDetector(0.8, 3.0, 2.0, 100.0)
-        );
-
-        StreamsRunner streamsRunner = AppUtil.createStreamsRunner(appConfig, builder);
-        AppUtil.launchStreamRunner(streamsRunner);
+        AppUtil.launchStreamRunner(new EwmaOutlierDetectorStreamRunnerBuilder().build(appConfig));
     }
 }

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaPewmaOutlierDetector.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaPewmaOutlierDetector.java
@@ -15,12 +15,8 @@
  */
 package com.expedia.adaptivealerting.kafka.detector;
 
-import com.expedia.adaptivealerting.anomdetect.PewmaAnomalyDetector;
 import com.expedia.adaptivealerting.kafka.util.AppUtil;
-import com.expedia.adaptivealerting.kafka.util.DetectorUtil;
-import com.expedia.www.haystack.commons.kstreams.app.StreamsRunner;
 import com.typesafe.config.Config;
-import org.apache.kafka.streams.StreamsBuilder;
 
 /**
  * Kafka Streams application for the PEWMA outlier detector.
@@ -31,13 +27,6 @@ public class KafkaPewmaOutlierDetector {
     
     public static void main(String[] args) {
         Config appConfig = AppUtil.getAppConfig("pewma-detector");
-
-        final StreamsBuilder builder = DetectorUtil.createDetectorStreamsBuilder(
-                appConfig.getString("topic"),
-                id -> new PewmaAnomalyDetector(0.05, 1.0, 2.0, 3.0, 100.0)
-        );
-
-        StreamsRunner streamsRunner = AppUtil.createStreamsRunner(appConfig, builder);
-        AppUtil.launchStreamRunner(streamsRunner);
+        AppUtil.launchStreamRunner(new PewmaOutlierDetectorStreamRunnerBuilder().build(appConfig));
     }
 }

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/PewmaOutlierDetectorStreamRunnerBuilder.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/PewmaOutlierDetectorStreamRunnerBuilder.java
@@ -15,13 +15,22 @@
  */
 package com.expedia.adaptivealerting.kafka.detector;
 
+import com.expedia.adaptivealerting.anomdetect.PewmaAnomalyDetector;
 import com.expedia.adaptivealerting.kafka.util.AppUtil;
+import com.expedia.adaptivealerting.kafka.util.DetectorUtil;
+import com.expedia.adaptivealerting.kafka.util.StreamRunnerBuilder;
+import com.expedia.www.haystack.commons.kstreams.app.StreamsRunner;
 import com.typesafe.config.Config;
+import org.apache.kafka.streams.StreamsBuilder;
 
-public class KafkaConstantThresholdOutlierDetector {
+public class PewmaOutlierDetectorStreamRunnerBuilder implements StreamRunnerBuilder {
+  @Override
+  public StreamsRunner build(Config appConfig) {
+    final StreamsBuilder builder = DetectorUtil.createDetectorStreamsBuilder(
+            appConfig.getString("topic"),
+            id -> new PewmaAnomalyDetector(0.05, 1.0, 2.0, 3.0, 100.0)
+    );
 
-    public static void main(String[] args) {
-        Config appConfig = AppUtil.getAppConfig("constant-detector");
-        AppUtil.launchStreamRunner(new ConstantThresholdOutlierDetectorStreamRunnerBuilder().build(appConfig));
-    }
+    return AppUtil.createStreamsRunner(appConfig, builder);
+  }
 }

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/router/MetricRouter.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/router/MetricRouter.java
@@ -16,46 +16,12 @@
 package com.expedia.adaptivealerting.kafka.router;
 
 import com.expedia.adaptivealerting.kafka.util.AppUtil;
-import com.expedia.www.haystack.commons.entities.MetricPoint;
-import com.expedia.www.haystack.commons.kstreams.app.StreamsRunner;
 import com.typesafe.config.Config;
-import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.kstream.KStream;
-
-import java.util.Arrays;
-import java.util.Collections;
 
 public class MetricRouter {
 
     public static void main(String[] args) {
         Config appConfig = AppUtil.getAppConfig("metricrouter");
-
-        final StreamsBuilder builder = createStreamsBuilder(appConfig);
-
-        StreamsRunner streamsRunner = AppUtil.createStreamsRunner(appConfig, builder);
-        AppUtil.launchStreamRunner(streamsRunner);
-    }
-
-    private static StreamsBuilder createStreamsBuilder(Config appConfig) {
-        final StreamsBuilder builder = new StreamsBuilder();
-        final KStream<String, MetricPoint> metrics = builder.stream(appConfig.getString("topic"));
-
-        metrics.filter(MetricRouter::isConstant).to("constant-metrics");
-        metrics.filter(MetricRouter::isEwma).to("ewma-metrics");
-        metrics.filter(MetricRouter::isPewma).to("pewma-metrics");
-        return builder;
-    }
-
-    // TODO: add real routing conditions
-    private static boolean isConstant(String key, MetricPoint metricPoint) {
-        return Arrays.asList("latency", "duration").contains(metricPoint.metric());
-    }
-
-    private static boolean isEwma(String key, MetricPoint metricPoint) {
-        return Collections.singletonList("ewma").contains(metricPoint.metric());
-    }
-
-    private static boolean isPewma(String key, MetricPoint metricPoint) {
-        return Collections.singletonList("pewma").contains(metricPoint.metric());
+        AppUtil.launchStreamRunner(new MetricRouterStreamBuilder().build(appConfig));
     }
 }

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/router/MetricRouterStreamBuilder.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/router/MetricRouterStreamBuilder.java
@@ -1,0 +1,45 @@
+package com.expedia.adaptivealerting.kafka.router;
+
+import com.expedia.adaptivealerting.kafka.util.AppUtil;
+import com.expedia.adaptivealerting.kafka.util.StreamRunnerBuilder;
+import com.expedia.www.haystack.commons.entities.MetricPoint;
+import com.expedia.www.haystack.commons.kstreams.app.StreamsRunner;
+import com.typesafe.config.Config;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.KStream;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class MetricRouterStreamBuilder implements StreamRunnerBuilder {
+  @Override
+  public StreamsRunner build(Config appConfig) {
+    final StreamsBuilder builder = createStreamsBuilder(appConfig);
+
+    return AppUtil.createStreamsRunner(appConfig, builder);
+  }
+
+  private static StreamsBuilder createStreamsBuilder(Config appConfig) {
+    final StreamsBuilder builder = new StreamsBuilder();
+    final KStream<String, MetricPoint> metrics = builder.stream(appConfig.getString("topic"));
+
+    metrics.filter(MetricRouterStreamBuilder::isConstant).to("constant-metrics");
+    metrics.filter(MetricRouterStreamBuilder::isEwma).to("ewma-metrics");
+    metrics.filter(MetricRouterStreamBuilder::isPewma).to("pewma-metrics");
+    return builder;
+  }
+
+  // TODO: add real routing conditions
+  private static boolean isConstant(String key, MetricPoint metricPoint) {
+    System.out.println("READ");
+    return Arrays.asList("latency", "duration").contains(metricPoint.metric());
+  }
+
+  private static boolean isEwma(String key, MetricPoint metricPoint) {
+    return Collections.singletonList("ewma").contains(metricPoint.metric());
+  }
+
+  private static boolean isPewma(String key, MetricPoint metricPoint) {
+    return Collections.singletonList("pewma").contains(metricPoint.metric());
+  }
+}

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/util/StreamRunnerBuilder.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/util/StreamRunnerBuilder.java
@@ -13,15 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.expedia.adaptivealerting.kafka.detector;
+package com.expedia.adaptivealerting.kafka.util;
 
-import com.expedia.adaptivealerting.kafka.util.AppUtil;
+import com.expedia.www.haystack.commons.kstreams.app.StreamsRunner;
 import com.typesafe.config.Config;
 
-public class KafkaConstantThresholdOutlierDetector {
-
-    public static void main(String[] args) {
-        Config appConfig = AppUtil.getAppConfig("constant-detector");
-        AppUtil.launchStreamRunner(new ConstantThresholdOutlierDetectorStreamRunnerBuilder().build(appConfig));
-    }
+public interface StreamRunnerBuilder {
+  StreamsRunner build(Config config);
 }

--- a/kafka/src/test/resources/config/base.conf
+++ b/kafka/src/test/resources/config/base.conf
@@ -1,0 +1,85 @@
+kstream.app.default {
+  streams {
+    bootstrap.servers = "kafkasvc:9092"
+    default.key.serde = "org.apache.kafka.common.serialization.Serdes$StringSerde"
+    default.value.serde = "com.expedia.www.haystack.commons.kstreams.serde.metricpoint.MetricTankSerde"
+  }
+  health.status.path = "/app/isHealthy"
+}
+
+metricrouter {
+  streams {
+    auto.offset.reset = "earliest"
+    cache.max.bytes.buffering = "0"
+    commit.interval.ms = "300"
+    state.dir = "/tmp/kafka-streams"
+    key.deserializer = "org.apache.kafka.common.serialization.StringDeserializer"
+    value.deserializer = "com.expedia.www.haystack.commons.kstreams.serde.metricpoint.MetricPointDeserializer"
+  }
+  topic = "metrics"
+  health.status.path = "/tmp/isAlive"
+}
+
+constant-detector {
+  streams {
+    auto.offset.reset = "earliest"
+    cache.max.bytes.buffering = "0"
+    commit.interval.ms = "300"
+    state.dir = "/tmp/kafka-streams"
+    key.deserializer = "org.apache.kafka.common.serialization.StringDeserializer"
+    value.deserializer = "com.expedia.www.haystack.commons.kstreams.serde.metricpoint.MetricPointDeserializer"
+  }
+  topic = "constant-metrics"
+  health.status.path = "/tmp/isAlive"
+}
+
+ewma-detector {
+  streams {
+    application.id = "ewma-detector"
+  }
+  topic = "ewma-metrics"
+}
+
+pewma-detector {
+  streams {
+    application.id = "pewma-detector"
+  }
+  topic = "pewma-metrics"
+}
+
+
+
+//Configs for kafka topic consumers - used to verify data in the topic
+
+anomalies-consumer {
+  streams {
+    auto.offset.reset = "earliest"
+    key.deserializer = "org.apache.kafka.common.serialization.StringDeserializer"
+    value.deserializer = "com.expedia.adaptivealerting.kafka.serde.JsonPojoDeserializer"
+  }
+  topic = "metrics"
+  health.status.path = "/tmp/isAlive"
+}
+
+constant-detector-consumer {
+  streams {
+    auto.offset.reset = "earliest"
+    key.deserializer = "org.apache.kafka.common.serialization.StringDeserializer"
+    value.deserializer = "com.expedia.www.haystack.commons.kstreams.serde.metricpoint.MetricPointDeserializer"
+  }
+  topic = "constant-metrics"
+  health.status.path = "/tmp/isAlive"
+}
+
+//Configs for producers to kafka topic - used to send test data to topics
+
+producer {
+  streams {
+    acks = "all"
+    retries = "0"
+    key.serializer = "org.apache.kafka.common.serialization.StringSerializer"
+    value.serializer = "com.expedia.www.haystack.commons.kstreams.serde.metricpoint.MetricPointSerializer"
+  }
+  topic = "constant-metrics"
+  health.status.path = "/tmp/isAlive"
+}

--- a/kafka/src/test/scala/com/expedia/adaptivealerting/pipeline/integration/IntegrationTestSpec.scala
+++ b/kafka/src/test/scala/com/expedia/adaptivealerting/pipeline/integration/IntegrationTestSpec.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expedia.adaptivealerting.pipeline.integration
+
+import java.util.Properties
+import java.util.concurrent.{Executors, ScheduledExecutorService, TimeUnit}
+
+import com.expedia.adaptivealerting.kafka.util.AppUtil
+import com.expedia.www.haystack.commons.entities.MetricPoint
+import com.typesafe.config.{Config, ConfigValue, ConfigValueFactory}
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.streams.integration.utils.{EmbeddedKafkaCluster, IntegrationTestUtils}
+import org.apache.kafka.streams.{KeyValue, StreamsConfig}
+import org.scalatest._
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.FiniteDuration
+
+object EmbeddedKafka {
+  val CLUSTER = new EmbeddedKafkaCluster(1)
+  CLUSTER.start()
+}
+
+class IntegrationTestSpec extends WordSpec with GivenWhenThen with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
+  protected var scheduler: ScheduledExecutorService = _
+  protected val PUNCTUATE_INTERVAL_MS = 2000
+  protected val INPUT_TOPIC = "metrics"
+  protected val OUTPUT_TOPIC = "anomalies"
+  val STREAM = "streams"
+
+  override def beforeAll() {
+    scheduler = Executors.newSingleThreadScheduledExecutor()
+  }
+
+  override def afterAll(): Unit = {
+    scheduler.shutdownNow()
+  }
+
+  protected def produceSpansAsync(produceInterval: FiniteDuration,
+                                  metrics: List[MetricPoint]): Unit = {
+    var currentTime = System.currentTimeMillis()
+    var idx = 0
+    scheduler.scheduleWithFixedDelay(() => {
+      if (idx < metrics.size) {
+        System.out.println("PUSH")
+        currentTime = currentTime + ((idx * PUNCTUATE_INTERVAL_MS) / (metrics.size - 1))
+        val metricPoint = metrics.apply(idx)
+        val records = List(new KeyValue[String, MetricPoint](metricPoint.metric, metricPoint)).asJava
+        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+          INPUT_TOPIC,
+          records,
+          producerConfigProperties,
+          currentTime)
+      }
+      idx = idx + 1
+    }, 0, produceInterval.toMillis, TimeUnit.MILLISECONDS)
+  }
+
+  def appConfig(key: String) : Config = {
+    AppUtil.getAppConfig(key).withValue(STREAM + "." + ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+      ConfigValueFactory.fromAnyRef(EmbeddedKafka.CLUSTER.bootstrapServers))
+  }
+
+  def consumerConfig(key: String, groupId: String) : Config = {
+    AppUtil.getAppConfig(key)
+      .withValue(STREAM + "." + ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                          ConfigValueFactory.fromAnyRef(EmbeddedKafka.CLUSTER.bootstrapServers))
+      .withValue(STREAM + "." + ConsumerConfig.GROUP_ID_CONFIG,
+                          ConfigValueFactory.fromAnyRef(groupId + "-consumer"))
+  }
+
+  def streamConfigProperties(key: String, appId: String) : Properties = {
+    val streamConfig  = AppUtil.getAppConfig(key).getConfig(STREAM)
+      .withValue(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+        ConfigValueFactory.fromAnyRef(EmbeddedKafka.CLUSTER.bootstrapServers))
+      .withValue(StreamsConfig.APPLICATION_ID_CONFIG,
+        ConfigValueFactory.fromAnyRef(appId))
+    configToProps(streamConfig)
+  }
+
+  def producerConfigProperties() : Properties = {
+    val prodConfig = AppUtil.getAppConfig("producer").getConfig(STREAM)
+      .withValue(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+        ConfigValueFactory.fromAnyRef(EmbeddedKafka.CLUSTER.bootstrapServers))
+    configToProps(prodConfig)
+  }
+
+  def configToProps(config: Config) = {
+    val props = new Properties
+    config.entrySet.forEach((entry: java.util.Map.Entry[String, ConfigValue]) => {
+      def setProperty(entry: java.util.Map.Entry[String, ConfigValue]) =
+        props.setProperty(entry.getKey, entry.getValue.unwrapped.toString)
+      setProperty(entry)
+    })
+    props
+  }
+
+}

--- a/kafka/src/test/scala/com/expedia/adaptivealerting/pipeline/integration/test/ConstantThresholdBasedE2ETestSpec.scala
+++ b/kafka/src/test/scala/com/expedia/adaptivealerting/pipeline/integration/test/ConstantThresholdBasedE2ETestSpec.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2018 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expedia.adaptivealerting.pipeline.integration.test
+
+import java.time.Instant
+
+import com.expedia.adaptivealerting.core.anomaly.AnomalyResult
+import com.expedia.adaptivealerting.core.util.MetricPointUtil.metricPoint
+import com.expedia.adaptivealerting.kafka.detector.ConstantThresholdOutlierDetectorStreamRunnerBuilder
+import com.expedia.adaptivealerting.kafka.router.MetricRouterStreamBuilder
+import com.expedia.adaptivealerting.pipeline.integration.{EmbeddedKafka, IntegrationTestSpec}
+import com.expedia.www.haystack.commons.entities.MetricPoint
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.streams.KeyValue
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+
+class ConstantThresholdBasedE2ETestSpec extends IntegrationTestSpec {
+  protected val INTERMEDIATE_TOPIC = "constant-metrics"
+  protected val metricRouterStreamConfig = streamConfigProperties("metricrouter", "metric-router")
+  protected val constantThresholdStreamConfig = streamConfigProperties("constant-detector", "constant-threshold-detector")
+  protected var constantThresholdTopicConsumerConfig = consumerConfig("constant-detector-consumer", "constant-threshold-detector")
+  protected var anomalyTopicConsumerConfig = consumerConfig("anomalies-consumer","anomaly")
+
+
+  override def beforeEach() {
+    EmbeddedKafka.CLUSTER.createTopic(INPUT_TOPIC)
+    EmbeddedKafka.CLUSTER.createTopic(INTERMEDIATE_TOPIC)
+    EmbeddedKafka.CLUSTER.createTopic(OUTPUT_TOPIC)
+    IntegrationTestUtils.purgeLocalStreamsState(metricRouterStreamConfig)
+    IntegrationTestUtils.purgeLocalStreamsState(constantThresholdStreamConfig)
+  }
+
+  override def afterEach(): Unit = {
+    EmbeddedKafka.CLUSTER.deleteTopic(INPUT_TOPIC)
+    EmbeddedKafka.CLUSTER.deleteTopic(INTERMEDIATE_TOPIC)
+    EmbeddedKafka.CLUSTER.deleteTopic(OUTPUT_TOPIC)
+  }
+
+  "AA with 'Constant Threshold Anomaly Detection' model" should {
+
+    "consume anomalous metrics from input topic, classify and confirm them as anomalies and " +
+      "send results to output topic" in {
+
+      Given("a set of anomalous metrics and kafka specific configurations")
+      val metrics = generateAnomalousMetrics()
+      val metricRouterSR = metricRouterStreamRunner
+      val constantThresholdSR = constantThresholdDetectorStreamRunner
+
+      When("anomalous metrics are produced in 'input' topic, and kafka-streams topology is started")
+      produceSpansAsync(10.millis, metrics)
+      metricRouterSR.start()
+      constantThresholdSR.start()
+
+      Then("'metric router' should route the metrics to 'constant threshold outlier detector' model's input topic")
+
+      val intermediateRecords: List[KeyValue[String, MetricPoint]] =
+        IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived[String, MetricPoint](
+          configToProps(constantThresholdTopicConsumerConfig.getConfig(STREAM)),
+          INTERMEDIATE_TOPIC, 2, 15000).asScala.toList // get metricPoints from Kafka's output topic
+      intermediateRecords.size shouldEqual 2
+      intermediateRecords.foreach(record => {
+        record.value.metric match {
+          case "duration" => "success"
+          case "latency" => "success"
+          case _ => fail("Unexpected metrics in input topic for 'constant threshold outlier detector'")
+        }
+      })
+
+
+      Then("'constant threshold outlier detector' should read records from its topic and " +
+        "write those anomalous records to output topic")
+      val consumerPropAnomalyTopic = configToProps(anomalyTopicConsumerConfig.getConfig(STREAM))
+      consumerPropAnomalyTopic.put("JsonPOJOClass", classOf[AnomalyResult])
+      val outputRecords: List[KeyValue[String, AnomalyResult]] =
+        IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived[String, AnomalyResult](
+          consumerPropAnomalyTopic,
+          OUTPUT_TOPIC, 2, 35000).asScala.toList // get metricPoints from Kafka's output topic
+      outputRecords.size shouldEqual 2
+
+      Then("no other intermediate partitions are created after as a result of topology")
+      val adminClient: AdminClient = AdminClient.create(metricRouterStreamConfig)
+      adminClient.listTopics().listings() should not be null
+      val topicNames: Iterable[String] = adminClient.listTopics.listings().get().asScala
+        .map(topicListing => topicListing.name)
+
+      topicNames.size shouldEqual 3
+      topicNames.toSet.contains(INPUT_TOPIC) shouldEqual true
+      topicNames.toSet.contains(INTERMEDIATE_TOPIC) shouldEqual true
+      topicNames.toSet.contains(OUTPUT_TOPIC) shouldEqual true
+    }
+  }
+
+  private def metricRouterStreamRunner = {
+    new MetricRouterStreamBuilder().build(appConfig("metricrouter"))
+  }
+
+  private def constantThresholdDetectorStreamRunner = {
+    new ConstantThresholdOutlierDetectorStreamRunnerBuilder().build(appConfig("constant-detector"))
+  }
+
+  private def generateAnomalousMetrics() : List[MetricPoint] = {
+    List(
+      metricPoint("latency", Instant.now(), 2),
+      metricPoint("duration", Instant.now(), 3)
+    )
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,14 @@
         <!-- Maven plugins -->
         <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
         <maven.jar.plugin.version>3.1.0</maven.jar.plugin.version>
+        <scalatest.version>3.0.3</scalatest.version>
+        <scala.major.version>2</scala.major.version>
+        <scala.minor.version>12</scala.minor.version>
+        <scala.major.minor.version>${scala.major.version}.${scala.minor.version}</scala.major.minor.version>
+        <scala.maintenance.version>2</scala.maintenance.version>
+        <scala-library.version>${scala.major.minor.version}.${scala.maintenance.version}</scala-library.version>
+        <pegdown.version>1.4.2</pegdown.version>
+        <kafka.version>1.1.0</kafka.version>
     </properties>
 
     <dependencyManagement>
@@ -121,6 +129,50 @@
                 <artifactId>slf4j-log4j12</artifactId>
                 <version>${slf4j.version}</version>
                 <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.scala-lang</groupId>
+                <artifactId>scala-library</artifactId>
+                <version>${scala-library.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.scalatest</groupId>
+                <artifactId>scalatest_${scala.major.minor.version}</artifactId>
+                <version>${scalatest.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.pegdown</groupId>
+                <artifactId>pegdown</artifactId>
+                <version>${pegdown.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-streams</artifactId>
+                <version>${kafka.version}</version>
+                <classifier>test</classifier>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>${kafka.version}</version>
+                <classifier>test</classifier>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka_${scala.major.minor.version}</artifactId>
+                <version>${kafka.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka_${scala.major.minor.version}</artifactId>
+                <version>${kafka.version}</version>
+                <classifier>test</classifier>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
1. Added a new module 'end2end.test' to hold all the e2e integration tests
2. StreamRunner creation logic from all the existing kstream apps have been moved to separate individual classes inorder to easily integrate with e2e tests.
3. ConstantThresholdBasedE2ETestSpec.scala tests the '(anomalous inputs)->(metric-router)->(constant-threshold-detector)->(output-topic)' E2E pipeline