### PR TITLE
Clarified the password that `make release` is requesting, per issue #63

### DIFF
--- a/scripts/publish-to-docker-hub.sh
+++ b/scripts/publish-to-docker-hub.sh
@@ -7,6 +7,7 @@ echo "DOCKER_ORG=$DOCKER_ORG, DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME, QUALIFIED_DO
 echo "BRANCH=$BRANCH, TAG=$TAG, SHA=$SHA"
 
 # login
+[[ -z $DOCKER_PASSWORD ]] && printf "\nPlease enter your docker.io password\n"
 docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
 
 # Add tags


### PR DESCRIPTION
The script formerly just asked for a password, and it wasn't clear (to me
at least) which password I needed to enter. To avoid mistakes I added a
clarifying prompt.