### PR TITLE
scripts and plugins to push jar to maven repo

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+cd `dirname $0`/..
+
+if [ -z "$SONATYPE_USERNAME" ]
+then
+    echo "ERROR! Please set SONATYPE_USERNAME and SONATYPE_PASSWORD environment variable"
+    exit 1
+fi
+
+if [ -z "$SONATYPE_PASSWORD" ]
+then
+    echo "ERROR! Please set SONATYPE_PASSWORD environment variable"
+    exit 1
+fi
+
+if [ ! -z "$GPG_SECRET_KEYS" ]
+then
+    echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import
+fi
+
+if [ ! -z "$GPG_OWNERTRUST" ]
+then
+    echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust
+fi
+
+if [ ! -z "$TRAVIS_TAG" ]
+then
+    SKIP_GPG_SIGN=false
+    echo "travis tag is set -> updating pom.xml <version> attribute to $TRAVIS_TAG"
+    ./mvnw --settings .travis/settings.xml org.codehaus.mojo:versions-maven-plugin:2.1:set -DnewVersion=$TRAVIS_TAG 1>/dev/null 2>/dev/null
+else
+    SKIP_GPG_SIGN=true
+    echo "no travis tag is set, hence keeping the snapshot version in pom.xml"
+fi
+
+./mvnw clean deploy --settings .travis/settings.xml -Dgpg.skip=$SKIP_GPG_SIGN -DskipTests=true -B -U
+
+echo "successfully deployed the jars to nexus"

--- a/.travis/settings.xml
+++ b/.travis/settings.xml
@@ -1,0 +1,25 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <!-- Maven Central Deployment -->
+            <id>ossrh</id>
+            <username>${env.SONATYPE_USERNAME}</username>
+            <password>${env.SONATYPE_PASSWORD}</password>
+        </server>
+    </servers>
+    <profiles>
+        <profile>
+            <id>ossrh</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <gpg.executable>${env.GPG_EXECUTABLE}</gpg.executable>
+                <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+            </properties>
+        </profile>
+    </profiles>
+</settings>

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: clean build
 # build all and release
 release: all
 	cd kafka && $(MAKE) release
-	./.travis/deploy.sh
+
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,57 @@
                     </archive>
                 </configuration>
             </plugin>
+            <!--Plugins requried for pushing jars to public maven repository-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Added 4 plugins
 - maven-javadoc-plugin : generates javadoc
-  maven-source-plugin: packages source code
-  maven-gpg-plugin: plugin to sign jar 
- nexus-staging-maven-plugin: plugin to stage jars before pushing to maven

all passwords and secret keys mention in deploy.sh have been configured on travis

I have removed call to deploy.sh for the time being
Will be added again when we want jars to be pushed to maven