### PR TITLE
removing incorrect tag to fix failing javadoc

### DIFF
--- a/tools/src/main/java/com/expedia/adaptivealerting/tools/pipeline/source/MetricFrameMetricSource.java
+++ b/tools/src/main/java/com/expedia/adaptivealerting/tools/pipeline/source/MetricFrameMetricSource.java
@@ -24,7 +24,7 @@ import java.time.Instant;
 import java.util.ListIterator;
 
 /**
- * Metric source backed by a {@MetricFrame}.
+ * Metric source backed by a MetricFrame.
  *
  * @author Willie Wheeler
  */


### PR DESCRIPTION
`@MetricFrame` throws error: unknown tag: MetricFrame on javadoc generation.
Didn't find a way to link a class in a seperate javadoc.
Removing this as it fails travis build.