### PR TITLE
Align Mpoint more closely with Haystack

### DIFF
--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/ConstantThresholdAnomalyDetector.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/ConstantThresholdAnomalyDetector.java
@@ -108,7 +108,7 @@ public class ConstantThresholdAnomalyDetector implements AnomalyDetector {
         final AnomalyResult result = new AnomalyResult();
         result.setMetric(mpoint.getMetric());
         result.setDetectorId(this.getId());
-        result.setEpochSecond(mpoint.getInstant().getEpochSecond());
+        result.setEpochSecond(mpoint.getEpochTimeInSeconds());
         result.setObserved(observed);
         result.setWeakThresholdUpper(weakThresholdUpper);
         result.setWeakThresholdLower(weakThresholdLower);

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/CusumAnomalyDetector.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/CusumAnomalyDetector.java
@@ -243,7 +243,7 @@ public class CusumAnomalyDetector implements AnomalyDetector {
         final AnomalyResult result = new AnomalyResult();
         result.setMetric(mpoint.getMetric());
         result.setDetectorId(this.getId());
-        result.setEpochSecond(mpoint.getInstant().getEpochSecond());
+        result.setEpochSecond(mpoint.getEpochTimeInSeconds());
         result.setObserved(observed);
         result.setPredicted(targetValue);
         result.setWeakThresholdUpper(weakThresholdUpper);

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/EwmaAnomalyDetector.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/EwmaAnomalyDetector.java
@@ -144,7 +144,7 @@ public class EwmaAnomalyDetector implements AnomalyDetector {
         final AnomalyResult result = new AnomalyResult();
         result.setMetric(mpoint.getMetric());
         result.setDetectorId(this.getId());
-        result.setEpochSecond(mpoint.getInstant().getEpochSecond());
+        result.setEpochSecond(mpoint.getEpochTimeInSeconds());
         result.setObserved(observed);
         result.setPredicted(mean);
         result.setWeakThresholdUpper(mean + weakThreshold);

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/PewmaAnomalyDetector.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/PewmaAnomalyDetector.java
@@ -190,7 +190,7 @@ public class PewmaAnomalyDetector implements AnomalyDetector {
         final AnomalyResult result = new AnomalyResult();
         result.setMetric(mpoint.getMetric());
         result.setDetectorId(this.getId());
-        result.setEpochSecond(mpoint.getInstant().getEpochSecond());
+        result.setEpochSecond(mpoint.getEpochTimeInSeconds());
         result.setObserved(observed);
         result.setPredicted(mean);
         result.setWeakThresholdUpper(mean + weakThreshold);

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/ConstantThresholdAnomalyDetectorTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/ConstantThresholdAnomalyDetectorTest.java
@@ -100,6 +100,6 @@ public class ConstantThresholdAnomalyDetectorTest {
     }
     
     private AnomalyLevel level(AnomalyDetector detector, Instant instant, float value) {
-        return detector.classify(MetricPointUtil.metricPoint(instant, value)).getAnomalyLevel();
+        return detector.classify(MetricPointUtil.metricPoint(instant.getEpochSecond(), value)).getAnomalyLevel();
     }
 }

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/CusumAnomalyDetectorTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/CusumAnomalyDetectorTest.java
@@ -64,7 +64,7 @@ public class CusumAnomalyDetectorTest {
         final int warmUpPeriod = 0;
         final double slackParam = 0.5;
         new CusumAnomalyDetector(tail, 10, slackParam, warmUpPeriod, WEAK_SIGMAS, STRONG_SIGMAS, 0.16)
-                .classify(MetricPointUtil.metricPoint(Instant.now(), observed));
+                .classify(MetricPointUtil.metricPoint(Instant.now().getEpochSecond(), observed));
     }
 
     @Test
@@ -86,7 +86,8 @@ public class CusumAnomalyDetectorTest {
         while (testRows.hasNext()) {
             final CusumTestRow testRow = testRows.next();
             final double observed = testRow.getObserved();
-            AnomalyResult result = detector.classify(MetricPointUtil.metricPoint(Instant.now(), observed));
+            AnomalyResult result =
+                    detector.classify(MetricPointUtil.metricPoint(Instant.now().getEpochSecond(), observed));
 
             if (noOfDataPoints < WARMUP_PERIOD) {
                 assertEquals(AnomalyLevel.valueOf("UNKNOWN"), result.getAnomalyLevel());

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/EwmaAnomalyDetectorTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/EwmaAnomalyDetectorTest.java
@@ -88,7 +88,7 @@ public class EwmaAnomalyDetectorTest {
             
             // This detector doesn't currently do anything with the instant, so we can just pass now().
             // This may change in the future.
-            detector.classify(MetricPointUtil.metricPoint(Instant.now(), observed));
+            detector.classify(MetricPointUtil.metricPoint(Instant.now().getEpochSecond(), observed));
             
             assertApproxEqual(testRow.getKnownMean(), testRow.getMean());
             assertApproxEqual(testRow.getMean(), detector.getMean());

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/PewmaAnomalyDetectorTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/PewmaAnomalyDetectorTest.java
@@ -69,8 +69,10 @@ public class PewmaAnomalyDetectorTest {
             assertApproxEqual(ewmaOutlierDetector.getMean(), pewmaOutlierDetector.getMean(), threshold);
             assertApproxEqual(ewmaStdDev, pewmaOutlierDetector.getStdDev(), threshold);
             
-            final AnomalyResult pewmaResult = pewmaOutlierDetector.classify(MetricPointUtil.metricPoint(Instant.now(), value));
-            final AnomalyResult ewmaResult = ewmaOutlierDetector.classify(MetricPointUtil.metricPoint(Instant.now(), value));
+            final AnomalyResult pewmaResult =
+                    pewmaOutlierDetector.classify(MetricPointUtil.metricPoint(Instant.now().getEpochSecond(), value));
+            final AnomalyResult ewmaResult =
+                    ewmaOutlierDetector.classify(MetricPointUtil.metricPoint(Instant.now().getEpochSecond(), value));
             
             AnomalyLevel pOL = pewmaResult.getAnomalyLevel();
             AnomalyLevel eOL = ewmaResult.getAnomalyLevel();
@@ -97,7 +99,8 @@ public class PewmaAnomalyDetectorTest {
             
             // This detector doesn't currently do anything with the instant, so we can just pass now().
             // This may change in the future.
-            final AnomalyResult result = detector.classify(MetricPointUtil.metricPoint(Instant.now(), (float) observed));
+            final AnomalyResult result =
+                    detector.classify(MetricPointUtil.metricPoint(Instant.now().getEpochSecond(), (float) observed));
             
             final AnomalyLevel level = result.getAnomalyLevel();
             assertApproxEqual(testRow.getMean(), detector.getMean(), 0.00001);

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/randomcutforest/MetricPointQueueTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/randomcutforest/MetricPointQueueTest.java
@@ -33,15 +33,15 @@ public class MetricPointQueueTest {
     public void isReadyTest() {
         queue = new Shingle();
 
-        queue.offer(MetricPointUtil.metricPoint(Instant.now(), Double.valueOf(1)));
+        queue.offer(MetricPointUtil.metricPoint(Instant.now().getEpochSecond(), Double.valueOf(1)));
         assertFalse(queue.isReady());
 
         for (int i = 2; i <= 10; i++) {
-            queue.offer(MetricPointUtil.metricPoint(Instant.now(), Double.valueOf(i)));
+            queue.offer(MetricPointUtil.metricPoint(Instant.now().getEpochSecond(), Double.valueOf(i)));
         }
         assertTrue(queue.isReady());
 
-        queue.offer(MetricPointUtil.metricPoint(Instant.now(), Double.valueOf(11)));
+        queue.offer(MetricPointUtil.metricPoint(Instant.now().getEpochSecond(), Double.valueOf(11)));
         assertTrue(queue.isReady());
     }
 
@@ -50,7 +50,7 @@ public class MetricPointQueueTest {
         queue = new Shingle();
 
         for (int i = 1; i <= 10; i++) {
-            queue.offer(MetricPointUtil.metricPoint(Instant.now(), Double.valueOf(i)));
+            queue.offer(MetricPointUtil.metricPoint(Instant.now().getEpochSecond(), Double.valueOf(i)));
         }
         assertTrue(queue.isReady());
         String out = queue.toCsv().get();

--- a/core/src/main/java/com/expedia/adaptivealerting/core/data/Mpoint.java
+++ b/core/src/main/java/com/expedia/adaptivealerting/core/data/Mpoint.java
@@ -15,8 +15,6 @@
  */
 package com.expedia.adaptivealerting.core.data;
 
-import java.time.Instant;
-
 /**
  * Metric point.
  *
@@ -24,24 +22,32 @@ import java.time.Instant;
  */
 public final class Mpoint {
     private Metric metric;
-    private Instant instant;
-    private Double value;
     
-    public Mpoint(Metric metric, Instant instant, Double value) {
-        this.metric = metric;
-        this.instant = instant;
-        this.value = value;
-    }
+    // TODO Prefer Instant and Double, but trying not to diverge much from Haystack's MetricPoint for now. [WLW]
+    private long epochTimeInSeconds;
+    private Float value;
     
     public Metric getMetric() {
         return metric;
     }
     
-    public Instant getInstant() {
-        return instant;
+    public void setMetric(Metric metric) {
+        this.metric = metric;
     }
     
-    public Double getValue() {
+    public long getEpochTimeInSeconds() {
+        return epochTimeInSeconds;
+    }
+    
+    public void setEpochTimeInSeconds(long epochTimeInSeconds) {
+        this.epochTimeInSeconds = epochTimeInSeconds;
+    }
+    
+    public Float getValue() {
         return value;
+    }
+    
+    public void setValue(Float value) {
+        this.value = value;
     }
 }

--- a/core/src/main/java/com/expedia/adaptivealerting/core/io/MetricFrameLoader.java
+++ b/core/src/main/java/com/expedia/adaptivealerting/core/io/MetricFrameLoader.java
@@ -73,12 +73,16 @@ public final class MetricFrameLoader {
         final int numRows = rows.size();
         final Mpoint[] mpoints = new Mpoint[numRows];
         for (int i = 0; i < numRows; i++) {
-            final String[] row = rows.get(i);
-            final Instant instant = Instant.parse(row[0]);
-            final Double value = Double.parseDouble(row[1]);
-            mpoints[i] = new Mpoint(metric, instant, value);
+            mpoints[i] = toMpoint(metric, rows.get(i));
         }
-        
         return new MetricFrame(mpoints);
+    }
+    
+    private static Mpoint toMpoint(Metric metric, String[] row) {
+        final Mpoint mpoint = new Mpoint();
+        mpoint.setMetric(metric);
+        mpoint.setEpochTimeInSeconds(Instant.parse(row[0]).getEpochSecond());
+        mpoint.setValue(Float.parseFloat(row[1]));
+        return mpoint;
     }
 }

--- a/core/src/main/java/com/expedia/adaptivealerting/core/util/MetricPointUtil.java
+++ b/core/src/main/java/com/expedia/adaptivealerting/core/util/MetricPointUtil.java
@@ -23,8 +23,6 @@ import scala.Enumeration;
 import scala.collection.immutable.Map;
 import scala.collection.immutable.Map$;
 
-import java.time.Instant;
-
 /**
  * {@link MetricPoint} utilities.
  *
@@ -43,27 +41,26 @@ public final class MetricPointUtil {
     /**
      * {@link MetricPoint} factory method. Metric points have name "data", type gauge and no tags.
      *
-     * @param instant Metric instant.
-     * @param value   Metric value.
+     * @param epochSecond Epoch time in seconds.
+     * @param value       Metric value.
      * @return Metric point.
      */
-    public static MetricPoint metricPoint(Instant instant, double value) {
-        return metricPoint("data", instant, value);
+    public static MetricPoint metricPoint(long epochSecond, double value) {
+        return metricPoint("data", epochSecond, value);
     }
     
     /**
      * {@link MetricPoint} factory method. Metric points have type gauge and no tags.
      *
-     * @param name    Metric name.
-     * @param instant Metric instant.
-     * @param value   Metric value.
+     * @param name        Metric name.
+     * @param epochSecond Epoch time in seconds.
+     * @param value       Metric value.
      * @return Metric point.
      */
-    public static MetricPoint metricPoint(String name, Instant instant, double value) {
-        long epochSecond = instant.getEpochSecond();
+    public static MetricPoint metricPoint(String name, long epochSecond, double value) {
         return new MetricPoint(name, DEFAULT_TYPE, DEFAULT_TAGS, (float) value, epochSecond);
     }
-
+    
     /**
      * Convert {@link MetricPoint} to a {@link Mpoint}.
      *
@@ -71,17 +68,17 @@ public final class MetricPointUtil {
      * @return an Mpoint.
      */
     public static Mpoint toMpoint(MetricPoint metricPoint) {
-        return new Mpoint(
-                toMetric(metricPoint),
-                Instant.ofEpochSecond(metricPoint.epochTimeInSeconds()),
-                (double) metricPoint.value()
-        );
+        final Mpoint mpoint = new Mpoint();
+        mpoint.setMetric(toMetric(metricPoint));
+        mpoint.setEpochTimeInSeconds(metricPoint.epochTimeInSeconds());
+        mpoint.setValue(metricPoint.value());
+        return mpoint;
     }
-
+    
     private static Metric toMetric(MetricPoint metricPoint) {
         Metric metric = new Metric();
         metric.addTags(scala.collection.JavaConverters
-            .mapAsJavaMapConverter(metricPoint.tags()).asJava());
+                .mapAsJavaMapConverter(metricPoint.tags()).asJava());
         return metric;
     }
 }

--- a/core/src/test/java/com/expedia/adaptivealerting/core/util/MetricPointUtilTest.java
+++ b/core/src/test/java/com/expedia/adaptivealerting/core/util/MetricPointUtilTest.java
@@ -36,7 +36,7 @@ public class MetricPointUtilTest {
     
     @Test
     public void testMetricPoint() {
-        final MetricPoint actual = metricPoint(Instant.now(), 1.414f);
+        final MetricPoint actual = metricPoint(Instant.now().getEpochSecond(), 1.414f);
         assertEquals("data", actual.metric());
     }
 

--- a/kafka/src/test/scala/com/expedia/adaptivealerting/pipeline/integration/test/ConstantThresholdBasedE2ETestSpec.scala
+++ b/kafka/src/test/scala/com/expedia/adaptivealerting/pipeline/integration/test/ConstantThresholdBasedE2ETestSpec.scala
@@ -117,8 +117,8 @@ class ConstantThresholdBasedE2ETestSpec extends IntegrationTestSpec {
 
   private def generateAnomalousMetrics() : List[MetricPoint] = {
     List(
-      metricPoint("latency", Instant.now(), 2),
-      metricPoint("failureCount", Instant.now(), 3)
+      metricPoint("latency", Instant.now().getEpochSecond, 2),
+      metricPoint("failureCount", Instant.now().getEpochSecond, 3)
     )
   }
 }

--- a/tools/src/main/java/com/expedia/adaptivealerting/tools/pipeline/source/MetricFrameMetricSource.java
+++ b/tools/src/main/java/com/expedia/adaptivealerting/tools/pipeline/source/MetricFrameMetricSource.java
@@ -20,7 +20,6 @@ import com.expedia.adaptivealerting.core.data.Mpoint;
 import com.expedia.adaptivealerting.core.util.MetricPointUtil;
 import com.expedia.www.haystack.commons.entities.MetricPoint;
 
-import java.time.Instant;
 import java.util.ListIterator;
 
 /**
@@ -40,9 +39,9 @@ public final class MetricFrameMetricSource extends AbstractMetricSource {
     public MetricPoint next() {
         if (mpoints.hasNext()) {
             final Mpoint mpoint = mpoints.next();
-            final Instant instant = mpoint.getInstant();
+            final long epochSecond = mpoint.getEpochTimeInSeconds();
             final float value = mpoint.getValue().floatValue();
-            return MetricPointUtil.metricPoint(instant, value);
+            return MetricPointUtil.metricPoint(epochSecond, value);
         } else {
             return null;
         }

--- a/tools/src/main/java/com/expedia/adaptivealerting/tools/pipeline/source/RandomWalkMetricSource.java
+++ b/tools/src/main/java/com/expedia/adaptivealerting/tools/pipeline/source/RandomWalkMetricSource.java
@@ -45,7 +45,7 @@ public final class RandomWalkMetricSource extends AbstractMetricSource {
     
     @Override
     public MetricPoint next() {
-        final MetricPoint result = metricPoint(getMetricName(), Instant.now(), currentValue);
+        final MetricPoint result = metricPoint(getMetricName(), Instant.now().getEpochSecond(), currentValue);
         final int movement = 1 - random.nextInt(3);
         this.currentValue += movement;
         return result;

--- a/tools/src/main/java/com/expedia/adaptivealerting/tools/pipeline/source/WhiteNoiseMetricSource.java
+++ b/tools/src/main/java/com/expedia/adaptivealerting/tools/pipeline/source/WhiteNoiseMetricSource.java
@@ -59,6 +59,6 @@ public final class WhiteNoiseMetricSource extends AbstractMetricSource {
     @Override
     public MetricPoint next() {
         final double value = mean + stdDev * random.nextGaussian();
-        return metricPoint(getMetricName(), Instant.now(), value);
+        return metricPoint(getMetricName(), Instant.now().getEpochSecond(), value);
     }
 }


### PR DESCRIPTION
Some internal integrations require a more incremental approach to
evolving the Haystack MetricPoint representation. Therefore I've updated
the AA Mpoint representation here to use epochTimeInSeconds and a Float
value, instead of using an Instant and a Double value.

I am still interested in using Instant and Double here, but we can have
that conversation after the basic integrations are working.