### PR TITLE
Added AnomalyDetectorManager, AnomalyDetectorFactory and Kafka support.

### DIFF
--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetector.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetector.java
@@ -16,6 +16,7 @@
 package com.expedia.adaptivealerting.anomdetect;
 
 import com.expedia.adaptivealerting.core.anomaly.AnomalyResult;
+import com.expedia.adaptivealerting.core.data.MappedMpoint;
 import com.expedia.www.haystack.commons.entities.MetricPoint;
 
 /**
@@ -31,9 +32,13 @@ public interface AnomalyDetector {
      * @param metricPoint Metric point.
      * @return Anomaly classification result, with supporting data such as the prediction, anomaly score and various
      * thresholds.
+     * @deprecated Deprecated in favor of {@link #classify(MappedMpoint)}.
      */
+    @Deprecated
     AnomalyResult classify(MetricPoint metricPoint);
-
+    
+    MappedMpoint classify(MappedMpoint mappedMpoint);
+    
     default String getId() {
         return this.toString(); // TODO: come up with an actual ID for detectors.
     }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetectorFactory.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetectorFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.anomdetect;
+
+import java.util.UUID;
+
+/**
+ * Anomaly detector factory.
+ *
+ * @author Willie Wheeler
+ */
+public interface AnomalyDetectorFactory<T extends AnomalyDetector> {
+    
+    /**
+     * Creates an anomaly detector. This could be a detector we load from persistent storage, or it could be entirely
+     * new, depending on the detector type.
+     *
+     * @param uuid Detector UUID.
+     * @return Anomaly detector.
+     */
+    T create(UUID uuid);
+}

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetectorManager.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetectorManager.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.anomdetect;
+
+import com.expedia.adaptivealerting.core.data.MappedMpoint;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
+
+/**
+ * Component that manages a given set of anomaly detectors
+ * @author David Sutherland
+ * @author Willie Wheeler
+ */
+public final class AnomalyDetectorManager {
+    
+    /**
+     * Factories that know how to produce anomaly detectors on demand.
+     */
+    private final Map<String, AnomalyDetectorFactory> detectorFactories;
+    
+    /**
+     * The managed detectors.
+     */
+    private final Map<UUID, AnomalyDetector> detectors = new HashMap<>();
+    
+    /**
+     * Creates a new anomaly detector manager.
+     *
+     * @param detectorFactories Mapping of detector types to their corresponding factories.
+     */
+    public AnomalyDetectorManager(Map<String, AnomalyDetectorFactory> detectorFactories) {
+        notNull(detectorFactories, "detectorFactories can't be null");
+        this.detectorFactories = detectorFactories;
+    }
+    
+    /**
+     * Gets the anomaly detector for the given metric point, creating it if absent.
+     *
+     * @param mappedMpoint Mapped metric point.
+     * @return Anomaly detector for the given metric point.
+     */
+    public AnomalyDetector detectorFor(MappedMpoint mappedMpoint) {
+        notNull(mappedMpoint, "mappedMpoint can't be null");
+        final UUID detectorUuid = mappedMpoint.getDetectorUuid();
+        AnomalyDetector detector = detectors.get(detectorUuid);
+        if (detector == null) {
+            final String detectorType = mappedMpoint.getDetectorType();
+            final AnomalyDetectorFactory factory = detectorFactories.get(detectorType);
+            detector = factory.create(detectorUuid);
+            detectors.put(detectorUuid, detector);
+        }
+        return detector;
+    }
+    
+    /**
+     * Convenience method to classify the mapped metric point, performing detector lookup behind the scenes. Note that
+     * this method has a side-effect in that it updates the passed mapped metric point itself.
+     *
+     * @param mappedMpoint Mapped metric point.
+     * @return The mapped metric point.
+     */
+    public MappedMpoint classify(MappedMpoint mappedMpoint) {
+        notNull(mappedMpoint, "mappedMpoint can't be null");
+        return detectorFor(mappedMpoint).classify(mappedMpoint);
+    }
+}

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/ConstantThresholdAnomalyDetector.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/ConstantThresholdAnomalyDetector.java
@@ -17,6 +17,7 @@ package com.expedia.adaptivealerting.anomdetect;
 
 import com.expedia.adaptivealerting.core.anomaly.AnomalyLevel;
 import com.expedia.adaptivealerting.core.anomaly.AnomalyResult;
+import com.expedia.adaptivealerting.core.data.MappedMpoint;
 import com.expedia.adaptivealerting.core.data.Mpoint;
 import com.expedia.adaptivealerting.core.util.AssertUtil;
 import com.expedia.adaptivealerting.core.util.MetricPointUtil;
@@ -116,6 +117,11 @@ public class ConstantThresholdAnomalyDetector implements AnomalyDetector {
         result.setStrongThresholdLower(strongThresholdLower);
         result.setAnomalyLevel(anomalyLevel);
         return result;
+    }
+    
+    @Override
+    public MappedMpoint classify(MappedMpoint mappedMpoint) {
+        throw new UnsupportedOperationException("Not yet implemented");
     }
 
     @Override

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/CusumAnomalyDetector.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/CusumAnomalyDetector.java
@@ -17,6 +17,7 @@ package com.expedia.adaptivealerting.anomdetect;
 
 import com.expedia.adaptivealerting.core.anomaly.AnomalyLevel;
 import com.expedia.adaptivealerting.core.anomaly.AnomalyResult;
+import com.expedia.adaptivealerting.core.data.MappedMpoint;
 import com.expedia.adaptivealerting.core.data.Mpoint;
 import com.expedia.adaptivealerting.core.util.AssertUtil;
 import com.expedia.adaptivealerting.core.util.MetricPointUtil;
@@ -253,6 +254,11 @@ public class CusumAnomalyDetector implements AnomalyDetector {
         result.setAnomalyScore(dist);
         result.setAnomalyLevel(anomalyLevel);
         return result;
+    }
+    
+    @Override
+    public MappedMpoint classify(MappedMpoint mappedMpoint) {
+        throw new UnsupportedOperationException("Not yet implemented");
     }
 
     private double getAverageMovingRange() {

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/EwmaAnomalyDetector.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/EwmaAnomalyDetector.java
@@ -17,6 +17,7 @@ package com.expedia.adaptivealerting.anomdetect;
 
 import com.expedia.adaptivealerting.core.anomaly.AnomalyLevel;
 import com.expedia.adaptivealerting.core.anomaly.AnomalyResult;
+import com.expedia.adaptivealerting.core.data.MappedMpoint;
 import com.expedia.adaptivealerting.core.data.Mpoint;
 import com.expedia.adaptivealerting.core.util.AssertUtil;
 import com.expedia.adaptivealerting.core.util.MetricPointUtil;
@@ -157,6 +158,11 @@ public class EwmaAnomalyDetector implements AnomalyDetector {
         updateEstimates(observed);
         
         return result;
+    }
+    
+    @Override
+    public MappedMpoint classify(MappedMpoint mappedMpoint) {
+        throw new UnsupportedOperationException("Not yet implemented");
     }
     
     private void updateEstimates(double value) {

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/PewmaAnomalyDetector.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/PewmaAnomalyDetector.java
@@ -17,6 +17,7 @@ package com.expedia.adaptivealerting.anomdetect;
 
 import com.expedia.adaptivealerting.core.anomaly.AnomalyLevel;
 import com.expedia.adaptivealerting.core.anomaly.AnomalyResult;
+import com.expedia.adaptivealerting.core.data.MappedMpoint;
 import com.expedia.adaptivealerting.core.data.Mpoint;
 import com.expedia.adaptivealerting.core.util.AssertUtil;
 import com.expedia.adaptivealerting.core.util.MetricPointUtil;
@@ -203,6 +204,11 @@ public class PewmaAnomalyDetector implements AnomalyDetector {
         updateEstimates(observed);
     
         return result;
+    }
+    
+    @Override
+    public MappedMpoint classify(MappedMpoint mappedMpoint) {
+        throw new UnsupportedOperationException("Not yet implemented");
     }
     
     private void updateEstimates(double value) {

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/randomcutforest/RandomCutForestAnomalyDetector.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/randomcutforest/RandomCutForestAnomalyDetector.java
@@ -19,13 +19,12 @@ import com.amazonaws.services.sagemakerruntime.AmazonSageMakerRuntime;
 import com.amazonaws.services.sagemakerruntime.AmazonSageMakerRuntimeClientBuilder;
 import com.amazonaws.services.sagemakerruntime.model.InvokeEndpointRequest;
 import com.amazonaws.services.sagemakerruntime.model.InvokeEndpointResult;
-
-
 import com.expedia.adaptivealerting.anomdetect.AnomalyDetector;
 import com.expedia.adaptivealerting.anomdetect.randomcutforest.beans.Scores;
 import com.expedia.adaptivealerting.anomdetect.randomcutforest.util.PropertiesCache;
 import com.expedia.adaptivealerting.core.anomaly.AnomalyLevel;
 import com.expedia.adaptivealerting.core.anomaly.AnomalyResult;
+import com.expedia.adaptivealerting.core.data.MappedMpoint;
 import com.expedia.adaptivealerting.core.util.AssertUtil;
 import com.expedia.www.haystack.commons.entities.MetricPoint;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -104,6 +103,11 @@ public class RandomCutForestAnomalyDetector implements AnomalyDetector {
             }
         }
         return result;
+    }
+    
+    @Override
+    public MappedMpoint classify(MappedMpoint mappedMpoint) {
+        throw new UnsupportedOperationException("Not yet implemented");
     }
 
     /**

--- a/core/src/main/java/com/expedia/adaptivealerting/core/data/MappedMpoint.java
+++ b/core/src/main/java/com/expedia/adaptivealerting/core/data/MappedMpoint.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.core.data;
+
+import com.expedia.adaptivealerting.core.anomaly.AnomalyResult;
+
+import java.util.UUID;
+
+/**
+ * Wraps an endpoint with a representation that includes anomaly detection information.
+ *
+ * @author Willie Wheeler
+ */
+public final class MappedMpoint {
+    private Mpoint mpoint;
+    private UUID detectorUuid;
+    private String detectorType;
+    private AnomalyResult anomalyResult;
+    
+    public Mpoint getMpoint() {
+        return mpoint;
+    }
+    
+    public void setMpoint(Mpoint mpoint) {
+        this.mpoint = mpoint;
+    }
+    
+    public UUID getDetectorUuid() {
+        return detectorUuid;
+    }
+    
+    public void setDetectorUuid(UUID detectorUuid) {
+        this.detectorUuid = detectorUuid;
+    }
+    
+    public String getDetectorType() {
+        return detectorType;
+    }
+    
+    public void setDetectorType(String detectorType) {
+        this.detectorType = detectorType;
+    }
+    
+    public AnomalyResult getAnomalyResult() {
+        return anomalyResult;
+    }
+    
+    public void setAnomalyResult(AnomalyResult anomalyResult) {
+        this.anomalyResult = anomalyResult;
+    }
+}

--- a/core/src/main/java/com/expedia/adaptivealerting/core/util/ConfigUtil.java
+++ b/core/src/main/java/com/expedia/adaptivealerting/core/util/ConfigUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.core.util;
+
+import com.typesafe.config.Config;
+
+import java.util.Properties;
+
+/**
+ * @author David Sutherland
+ * @author Willie Wheeler
+ */
+public final class ConfigUtil {
+    
+    /**
+     * Prevent instantiation.
+     */
+    private ConfigUtil() {
+    }
+    
+    /**
+     * Maps a configuration instance to a properties instance.
+     *
+     * @param config Configuration instance.
+     * @return Properties instance.
+     */
+    public static Properties toProperties(Config config) {
+        final Properties props = new Properties();
+        config.entrySet().forEach((entry) -> {
+            props.setProperty(entry.getKey(), entry.getValue().unwrapped().toString());
+        });
+        return props;
+    }
+}

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/AbstractKafkaApp.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/AbstractKafkaApp.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.kafka;
+
+import com.codahale.metrics.JmxReporter;
+import com.expedia.adaptivealerting.core.util.ConfigUtil;
+import com.expedia.www.haystack.commons.health.HealthStatusController;
+import com.expedia.www.haystack.commons.health.UpdateHealthStatusFile;
+import com.expedia.www.haystack.commons.kstreams.app.Application;
+import com.expedia.www.haystack.commons.kstreams.app.StateChangeListener;
+import com.expedia.www.haystack.commons.kstreams.app.StreamsFactory;
+import com.expedia.www.haystack.commons.kstreams.app.StreamsRunner;
+import com.expedia.www.haystack.commons.metrics.MetricsRegistries;
+import com.typesafe.config.Config;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+
+import java.util.Properties;
+
+import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
+
+/**
+ * Abstract base class for creating Kafka apps.
+ *
+ * @author David Sutherland
+ * @author Willie Wheeler
+ */
+public abstract class AbstractKafkaApp {
+    private final Config kafkaConfig;
+    private final Application application;
+    
+    public AbstractKafkaApp(Config kafkaConfig) {
+        notNull(kafkaConfig, "kafkaConfig can't be null");
+        this.kafkaConfig = kafkaConfig;
+        this.application = application();
+    }
+    
+    public Config getKafkaConfig() {
+        return kafkaConfig;
+    }
+    
+    public void start() {
+        application.start();
+    }
+    
+    /**
+     * Implementations must provide an application topology using this method.
+     *
+     * @return A topology builder.
+     */
+    protected abstract StreamsBuilder streamsBuilder();
+    
+    private Application application() {
+        final Application app = new Application(streamsRunner(), jmxReporter());
+        Runtime.getRuntime().addShutdownHook(new Thread(app::stop));
+        return app;
+    }
+    
+    private StreamsRunner streamsRunner() {
+        return new StreamsRunner(streamsFactory(), healthListener());
+    }
+    
+    private StreamsFactory streamsFactory() {
+        final StreamsBuilder builder = streamsBuilder();
+        final Properties props = ConfigUtil.toProperties(kafkaConfig.getConfig("streams"));
+        final StreamsConfig streamsConfig = new StreamsConfig(props);
+        final String topic = kafkaConfig.getString("topic");
+        return new StreamsFactory(builder::build, streamsConfig, topic);
+    }
+    
+    private StateChangeListener healthListener() {
+        final HealthStatusController controller = new HealthStatusController();
+        final String path = kafkaConfig.getString("health.status.path");
+        controller.addListener(new UpdateHealthStatusFile(path));
+        return new StateChangeListener(controller);
+    }
+    
+    private JmxReporter jmxReporter() {
+        return JmxReporter.forRegistry(MetricsRegistries.metricRegistry()).build();
+    }
+}

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaAnomalyDetectorManager.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaAnomalyDetectorManager.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.kafka.detector;
+
+import com.expedia.adaptivealerting.anomdetect.AnomalyDetectorManager;
+import com.expedia.adaptivealerting.core.data.MappedMpoint;
+import com.expedia.adaptivealerting.kafka.AbstractKafkaApp;
+import com.expedia.adaptivealerting.kafka.serde.JsonPojoDeserializer;
+import com.expedia.adaptivealerting.kafka.serde.JsonPojoSerializer;
+import com.expedia.adaptivealerting.kafka.serde.MpointTimestampExtractor;
+import com.typesafe.config.Config;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.Consumed;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Produced;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
+
+/**
+ * Kafka wrapper around {@link AnomalyDetectorManager}.
+ *
+ * @author David Sutherland
+ * @author Willie Wheeler
+ */
+public final class KafkaAnomalyDetectorManager extends AbstractKafkaApp {
+    
+    // TODO Externalize this to the Kafka config. [WLW]
+    private static final String ANOMALY_TOPIC = "anomalies";
+    
+    private AnomalyDetectorManager manager;
+    
+    public KafkaAnomalyDetectorManager(Config kafkaConfig, AnomalyDetectorManager manager) {
+        super(kafkaConfig);
+        notNull(manager, "manager can't be null");
+        this.manager = manager;
+    }
+    
+    @Override
+    protected StreamsBuilder streamsBuilder() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final String topic = getKafkaConfig().getString("topic");
+        final KStream<String, MappedMpoint> stream = builder.stream(topic, jsonMpointSerde());
+        stream
+                .map((key, mappedMpoint) -> KeyValue.pair(key, manager.classify(mappedMpoint)))
+                .to(ANOMALY_TOPIC, jsonAnomalySerde());
+        return builder;
+    }
+    
+    private Consumed<String, MappedMpoint> jsonMpointSerde() {
+        final JsonPojoDeserializer<MappedMpoint> deserializer = new JsonPojoDeserializer<>();
+        final Map<String, Object> props = new HashMap<>();
+        props.put("JsonPojoClass", MappedMpoint.class);
+        deserializer.configure(props, false);
+        
+        return Consumed.with(
+                new Serdes.StringSerde(),
+                Serdes.serdeFrom(new JsonPojoSerializer<>(), deserializer),
+                new MpointTimestampExtractor(),
+                Topology.AutoOffsetReset.LATEST);
+    }
+    
+    private Produced<String, MappedMpoint> jsonAnomalySerde() {
+        // TODO Add StreamPartitioner
+        return Produced.with(
+                new Serdes.StringSerde(),
+                Serdes.serdeFrom(new JsonPojoSerializer<>(), new JsonPojoDeserializer<>()));
+    }
+}

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaConstantThresholdOutlierDetector.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaConstantThresholdOutlierDetector.java
@@ -25,6 +25,8 @@ import org.apache.kafka.streams.StreamsBuilder;
 
 import static com.expedia.adaptivealerting.anomdetect.ConstantThresholdAnomalyDetector.RIGHT_TAILED;
 
+// TODO Rename to KafkaConstantThresholdAnomalyDetector. [WLW]
+
 public class KafkaConstantThresholdOutlierDetector {
 
     public static void main(String[] args) {

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaEwmaOutlierDetector.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaEwmaOutlierDetector.java
@@ -23,6 +23,8 @@ import com.expedia.www.haystack.commons.kstreams.app.StreamsRunner;
 import com.typesafe.config.Config;
 import org.apache.kafka.streams.StreamsBuilder;
 
+// TODO Rename to KafkaEwmaAnomalyDetector. [WLW]
+
 /**
  * Kafka Streams application for the EWMA outlier detector.
  *

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaPewmaOutlierDetector.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaPewmaOutlierDetector.java
@@ -23,6 +23,8 @@ import com.expedia.www.haystack.commons.kstreams.app.StreamsRunner;
 import com.typesafe.config.Config;
 import org.apache.kafka.streams.StreamsBuilder;
 
+// TODO Rename to KafkaPewmaAnomalyDetector. [WLW]
+
 /**
  * Kafka Streams application for the PEWMA outlier detector.
  *

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/router/MetricRouter.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/router/MetricRouter.java
@@ -33,6 +33,7 @@ public class MetricRouter {
     }
 
     public static class StreamRunnerBuilder extends BaseStreamRunnerBuilder {
+        
         @Override
         public StreamsRunner build(Config appConfig) {
             final StreamsBuilder builder = createStreamsBuilder(appConfig);

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/serde/HaystackMetricTimeStampExtractor.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/serde/HaystackMetricTimeStampExtractor.java
@@ -25,9 +25,11 @@ import org.slf4j.LoggerFactory;
  * Timestamp extractor for MetricPoints
  * similar to class {@link org.apache.kafka.streams.processor.LogAndSkipOnInvalidTimestamp}
  * adding this as com.expedia.www.haystack.commons.kstreams.MetricPointTimestampExtractor doesn't handle this
-
+ *
  * @author shsethi
+ * @deprecated Deprecated in favor of {@link MpointTimestampExtractor}.
  */
+@Deprecated
 public class HaystackMetricTimeStampExtractor implements TimestampExtractor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HaystackMetricTimeStampExtractor.class);

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/serde/MpointTimestampExtractor.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/serde/MpointTimestampExtractor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.kafka.serde;
+
+import com.expedia.adaptivealerting.core.data.Mpoint;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.streams.processor.TimestampExtractor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Timestamp extractor for {@link Mpoint}, similar to
+ * {@link org.apache.kafka.streams.processor.LogAndSkipOnInvalidTimestamp}.
+ * Adding this as com.expedia.www.haystack.commons.kstreams.MetricPointTimestampExtractor doesn't handle null values.
+ *
+ * @author Shubham Sethi
+ * @author Willie Wheeler
+ */
+public class MpointTimestampExtractor implements TimestampExtractor {
+    private static final Logger log = LoggerFactory.getLogger(MpointTimestampExtractor.class);
+    
+    @Override
+    public long extract(ConsumerRecord<Object, Object> record, long previousTimestamp) {
+        Mpoint mpoint = (Mpoint) record.value();
+        if (mpoint == null) {
+            // -1 skips the record.
+            log.warn("Skipping null Mpoint");
+            return -1L;
+        }
+        
+        return mpoint.getEpochTimeInSeconds() * 1000L;
+    }
+}

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/util/AppUtil.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/util/AppUtil.java
@@ -22,7 +22,8 @@ import com.expedia.www.haystack.commons.kstreams.app.StreamsRunner;
 import com.expedia.www.haystack.commons.metrics.MetricsRegistries;
 import com.typesafe.config.Config;
 
-public class AppUtil {
+public final class AppUtil {
+    
     /**
      * Prevent instantiation.
      */
@@ -30,19 +31,19 @@ public class AppUtil {
     }
 
     public static Config getAppConfig(String configKey) {
+        // TODO Remove Haystack-specific references. [WLW]
         Config config = ConfigurationLoader.loadConfigFileWithEnvOverrides("config/base.conf", "HAYSTACK_PROP_");
         return config.getConfig(configKey).withFallback(config.getConfig("kstream.app.default"));
     }
-
+    
+    /**
+     * @deprecated Deprecated in favor of {@link com.expedia.adaptivealerting.kafka.AbstractKafkaApp}.
+     */
+    @Deprecated
     public static void launchStreamRunner(StreamsRunner streamsRunner) {
-        //create an instance of the application
         JmxReporter jmxReporter = JmxReporter.forRegistry(MetricsRegistries.metricRegistry()).build();
         Application app = new Application(streamsRunner, jmxReporter);
-
-        //start the application
-        app.start();
-
-        //add a shutdown hook
         Runtime.getRuntime().addShutdownHook(new Thread(app::stop));
+        app.start();
     }
 }

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/util/BaseStreamRunnerBuilder.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/util/BaseStreamRunnerBuilder.java
@@ -26,6 +26,10 @@ import org.apache.kafka.streams.StreamsConfig;
 
 import java.util.Properties;
 
+/**
+ * @deprecated Deprecated in favor of {@link com.expedia.adaptivealerting.kafka.AbstractKafkaApp}.
+ */
+@Deprecated
 public abstract class BaseStreamRunnerBuilder {
     public abstract StreamsRunner build(Config config);
 

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/util/DetectorUtil.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/util/DetectorUtil.java
@@ -17,6 +17,7 @@ package com.expedia.adaptivealerting.kafka.util;
 
 import com.expedia.adaptivealerting.anomdetect.AnomalyDetector;
 import com.expedia.adaptivealerting.core.anomaly.AnomalyResult;
+import com.expedia.adaptivealerting.kafka.detector.KafkaAnomalyDetectorManager;
 import com.expedia.adaptivealerting.kafka.serde.JsonPojoSerializer;
 import com.expedia.adaptivealerting.kafka.serde.JsonPojoDeserializer;
 import com.expedia.www.haystack.commons.entities.MetricPoint;
@@ -34,8 +35,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
+/**
+ * @deprecated Deprecated in favor of {@link KafkaAnomalyDetectorManager}.
+ */
+@Deprecated
 public class DetectorUtil {
-    static final String OUTLIER_LEVEL_TAG = "outlierLevel";
 
     // FIXME Hack because I'm not sure how to handle null MetricPoints below.
     // But definitely don't want to keep this as it messes up the model.
@@ -78,6 +82,7 @@ public class DetectorUtil {
     }
 
     static String extractMetricId(MetricPoint metricPoint) {
-        return metricPoint.getMetricPointKey(ENCODER); // TODO: find out how we'll be getting the ids.
+        // TODO: find out how we'll be getting the ids.
+        return metricPoint.getMetricPointKey(ENCODER);
     }
 }


### PR DESCRIPTION
This commit isolates some key capabilities from the Kafka code:

- Anomaly detector management is no longer tied to Kafka, since we need
  management no matter what infrastructure we're using. This is now in the
  AnomalyDetectorManager class.
- It adds an AnomalyDetectorFactory class so the manager can produce
  detectors on demand.
- It introduces a MappedMpoint class, which is similar to AnomalyResult
  except that it's backed my Mpoint instead of Haystack's MetricPoint,
  which we're trying to remove. I'm not necessarily attached to the names
  "Mpoint" and "MappedMpoint", so we can rename those if desired after we
  get rid of the Haystack MetricPoint.
- I changed the AnomalyDetector interface to handle classifications based
  on MappedMpoint, but didn't change any of the detectors yet (other than
  implementing "throws new UnsupportedOperationException()" on the
  subclasses til we move over).
- Kafka base class support is cleaned up.