### PR TITLE
Enhancement/kafka adm main

### DIFF
--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetectorFactory.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetectorFactory.java
@@ -26,7 +26,7 @@ import java.util.UUID;
  */
 public interface AnomalyDetectorFactory<T extends AnomalyDetector> {
     
-    void init(Config config);
+    void init(Config appConfig);
     
     /**
      * Creates an anomaly detector. This would usually involve looking up at least the model parameters from persistent

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetectorManager.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetectorManager.java
@@ -24,7 +24,8 @@ import java.util.UUID;
 import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
 
 /**
- * Component that manages a given set of anomaly detectors
+ * Component that manages a given set of anomaly detectors.
+ *
  * @author David Sutherland
  * @author Willie Wheeler
  */

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/ConstantThresholdAnomalyDetectorFactory.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/ConstantThresholdAnomalyDetectorFactory.java
@@ -19,22 +19,22 @@ import com.typesafe.config.Config;
 
 import java.util.UUID;
 
+import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
+
 /**
- * Anomaly detector factory.
- *
  * @author Willie Wheeler
  */
-public interface AnomalyDetectorFactory<T extends AnomalyDetector> {
+public class ConstantThresholdAnomalyDetectorFactory implements AnomalyDetectorFactory<CusumAnomalyDetector> {
     
-    void init(Config config);
+    @Override
+    public void init(Config config) {
+        notNull(config, "config can't be null");
+    }
     
-    /**
-     * Creates an anomaly detector. This would usually involve looking up at least the model parameters from persistent
-     * storages, based on automated model selection and autotuning. In many cases it would involve looking up a
-     * pretrained model.
-     *
-     * @param uuid Detector UUID.
-     * @return Anomaly detector.
-     */
-    T create(UUID uuid);
+    @Override
+    public CusumAnomalyDetector create(UUID uuid) {
+        notNull(uuid, "uuid can't be null");
+        // TODO Look up bounds based on UUID.
+        return null;
+    }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/ConstantThresholdAnomalyDetectorFactory.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/ConstantThresholdAnomalyDetectorFactory.java
@@ -27,8 +27,8 @@ import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
 public class ConstantThresholdAnomalyDetectorFactory implements AnomalyDetectorFactory<CusumAnomalyDetector> {
     
     @Override
-    public void init(Config config) {
-        notNull(config, "config can't be null");
+    public void init(Config appConfig) {
+        notNull(appConfig, "appConfig can't be null");
     }
     
     @Override

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/ConstantThresholdAnomalyDetectorFactory.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/ConstantThresholdAnomalyDetectorFactory.java
@@ -24,7 +24,8 @@ import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
 /**
  * @author Willie Wheeler
  */
-public class ConstantThresholdAnomalyDetectorFactory implements AnomalyDetectorFactory<CusumAnomalyDetector> {
+public class ConstantThresholdAnomalyDetectorFactory
+        implements AnomalyDetectorFactory<ConstantThresholdAnomalyDetector> {
     
     @Override
     public void init(Config appConfig) {
@@ -32,7 +33,7 @@ public class ConstantThresholdAnomalyDetectorFactory implements AnomalyDetectorF
     }
     
     @Override
-    public CusumAnomalyDetector create(UUID uuid) {
+    public ConstantThresholdAnomalyDetector create(UUID uuid) {
         notNull(uuid, "uuid can't be null");
         // TODO Look up bounds based on UUID.
         return null;

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/CusumAnomalyDetectorFactory.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/CusumAnomalyDetectorFactory.java
@@ -27,8 +27,8 @@ import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
 public final class CusumAnomalyDetectorFactory implements AnomalyDetectorFactory<CusumAnomalyDetector> {
     
     @Override
-    public void init(Config config) {
-        notNull(config, "config can't be null");
+    public void init(Config appConfig) {
+        notNull(appConfig, "appConfig can't be null");
     }
     
     @Override

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/CusumAnomalyDetectorFactory.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/CusumAnomalyDetectorFactory.java
@@ -19,22 +19,22 @@ import com.typesafe.config.Config;
 
 import java.util.UUID;
 
+import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
+
 /**
- * Anomaly detector factory.
- *
  * @author Willie Wheeler
  */
-public interface AnomalyDetectorFactory<T extends AnomalyDetector> {
+public final class CusumAnomalyDetectorFactory implements AnomalyDetectorFactory<CusumAnomalyDetector> {
     
-    void init(Config config);
+    @Override
+    public void init(Config config) {
+        notNull(config, "config can't be null");
+    }
     
-    /**
-     * Creates an anomaly detector. This would usually involve looking up at least the model parameters from persistent
-     * storages, based on automated model selection and autotuning. In many cases it would involve looking up a
-     * pretrained model.
-     *
-     * @param uuid Detector UUID.
-     * @return Anomaly detector.
-     */
-    T create(UUID uuid);
+    @Override
+    public CusumAnomalyDetector create(UUID uuid) {
+        notNull(uuid, "uuid can't be null");
+        // TODO Look up params
+        return null;
+    }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/EwmaAnomalyDetectorFactory.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/EwmaAnomalyDetectorFactory.java
@@ -27,8 +27,8 @@ import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
 public final class EwmaAnomalyDetectorFactory implements AnomalyDetectorFactory<EwmaAnomalyDetector> {
     
     @Override
-    public void init(Config config) {
-        notNull(config, "config can't be null");
+    public void init(Config appConfig) {
+        notNull(appConfig, "appConfig can't be null");
     }
     
     @Override

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/EwmaAnomalyDetectorFactory.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/EwmaAnomalyDetectorFactory.java
@@ -19,22 +19,22 @@ import com.typesafe.config.Config;
 
 import java.util.UUID;
 
+import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
+
 /**
- * Anomaly detector factory.
- *
  * @author Willie Wheeler
  */
-public interface AnomalyDetectorFactory<T extends AnomalyDetector> {
+public final class EwmaAnomalyDetectorFactory implements AnomalyDetectorFactory<EwmaAnomalyDetector> {
     
-    void init(Config config);
+    @Override
+    public void init(Config config) {
+        notNull(config, "config can't be null");
+    }
     
-    /**
-     * Creates an anomaly detector. This would usually involve looking up at least the model parameters from persistent
-     * storages, based on automated model selection and autotuning. In many cases it would involve looking up a
-     * pretrained model.
-     *
-     * @param uuid Detector UUID.
-     * @return Anomaly detector.
-     */
-    T create(UUID uuid);
+    @Override
+    public EwmaAnomalyDetector create(UUID uuid) {
+        notNull(uuid, "uuid can't be null");
+        // TODO Look up params
+        return null;
+    }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/PewmaAnomalyDetectorFactory.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/PewmaAnomalyDetectorFactory.java
@@ -19,22 +19,22 @@ import com.typesafe.config.Config;
 
 import java.util.UUID;
 
+import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
+
 /**
- * Anomaly detector factory.
- *
  * @author Willie Wheeler
  */
-public interface AnomalyDetectorFactory<T extends AnomalyDetector> {
+public final class PewmaAnomalyDetectorFactory implements AnomalyDetectorFactory<PewmaAnomalyDetector> {
     
-    void init(Config config);
+    public void init(Config config) {
+        notNull(config, "config can't be null");
+        // TODO
+    }
     
-    /**
-     * Creates an anomaly detector. This would usually involve looking up at least the model parameters from persistent
-     * storages, based on automated model selection and autotuning. In many cases it would involve looking up a
-     * pretrained model.
-     *
-     * @param uuid Detector UUID.
-     * @return Anomaly detector.
-     */
-    T create(UUID uuid);
+    @Override
+    public PewmaAnomalyDetector create(UUID uuid) {
+        notNull(uuid, "uuid can't be null");
+        // TODO Look up params
+        return null;
+    }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/PewmaAnomalyDetectorFactory.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/PewmaAnomalyDetectorFactory.java
@@ -26,8 +26,8 @@ import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
  */
 public final class PewmaAnomalyDetectorFactory implements AnomalyDetectorFactory<PewmaAnomalyDetector> {
     
-    public void init(Config config) {
-        notNull(config, "config can't be null");
+    public void init(Config appConfig) {
+        notNull(appConfig, "appConfig can't be null");
         // TODO
     }
     

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/randomcutforest/RandomCutForestAnomalyDetectorFactory.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/randomcutforest/RandomCutForestAnomalyDetectorFactory.java
@@ -29,8 +29,8 @@ public final class RandomCutForestAnomalyDetectorFactory
         implements AnomalyDetectorFactory<RandomCutForestAnomalyDetector> {
     
     @Override
-    public void init(Config config) {
-        notNull(config, "config can't be null");
+    public void init(Config appConfig) {
+        notNull(appConfig, "appConfig can't be null");
         // TODO
     }
     

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/randomcutforest/RandomCutForestAnomalyDetectorFactory.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/randomcutforest/RandomCutForestAnomalyDetectorFactory.java
@@ -13,28 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.expedia.adaptivealerting.anomdetect;
+package com.expedia.adaptivealerting.anomdetect.randomcutforest;
 
+import com.expedia.adaptivealerting.anomdetect.AnomalyDetectorFactory;
 import com.typesafe.config.Config;
 
 import java.util.UUID;
 
+import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
+
 /**
- * Anomaly detector factory.
- *
  * @author Willie Wheeler
  */
-public interface AnomalyDetectorFactory<T extends AnomalyDetector> {
+public final class RandomCutForestAnomalyDetectorFactory
+        implements AnomalyDetectorFactory<RandomCutForestAnomalyDetector> {
     
-    void init(Config config);
+    @Override
+    public void init(Config config) {
+        notNull(config, "config can't be null");
+        // TODO
+    }
     
-    /**
-     * Creates an anomaly detector. This would usually involve looking up at least the model parameters from persistent
-     * storages, based on automated model selection and autotuning. In many cases it would involve looking up a
-     * pretrained model.
-     *
-     * @param uuid Detector UUID.
-     * @return Anomaly detector.
-     */
-    T create(UUID uuid);
+    @Override
+    public RandomCutForestAnomalyDetector create(UUID uuid) {
+        notNull(uuid, "uuid can't be null");
+        // TODO Look up model
+        return null;
+    }
 }

--- a/core/src/main/java/com/expedia/adaptivealerting/core/data/MappedMpoint.java
+++ b/core/src/main/java/com/expedia/adaptivealerting/core/data/MappedMpoint.java
@@ -20,7 +20,12 @@ import com.expedia.adaptivealerting.core.anomaly.AnomalyResult;
 import java.util.UUID;
 
 /**
+ * <p>
  * Wraps an endpoint with a representation that includes anomaly detection information.
+ * </p>
+ * <p>
+ * By contract the {@link Mpoint} must be set.
+ * </p>
  *
  * @author Willie Wheeler
  */

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/AbstractKafkaApp.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/AbstractKafkaApp.java
@@ -31,6 +31,9 @@ import org.apache.kafka.streams.StreamsConfig;
 import java.util.Properties;
 
 import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
+import static com.expedia.adaptivealerting.kafka.KafkaConfigProps.HEALTH_STATUS_PATH;
+import static com.expedia.adaptivealerting.kafka.KafkaConfigProps.INBOUND_TOPIC;
+import static com.expedia.adaptivealerting.kafka.KafkaConfigProps.STREAMS;
 
 /**
  * Abstract base class for creating Kafka apps.
@@ -39,17 +42,17 @@ import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
  * @author Willie Wheeler
  */
 public abstract class AbstractKafkaApp {
-    private final Config kafkaConfig;
+    private final Config appConfig;
     private final Application application;
     
-    public AbstractKafkaApp(Config kafkaConfig) {
-        notNull(kafkaConfig, "kafkaConfig can't be null");
-        this.kafkaConfig = kafkaConfig;
+    public AbstractKafkaApp(Config appConfig) {
+        notNull(appConfig, "appConfig can't be null");
+        this.appConfig = appConfig;
         this.application = application();
     }
     
-    public Config getKafkaConfig() {
-        return kafkaConfig;
+    public Config getAppConfig() {
+        return appConfig;
     }
     
     public void start() {
@@ -75,15 +78,15 @@ public abstract class AbstractKafkaApp {
     
     private StreamsFactory streamsFactory() {
         final StreamsBuilder builder = streamsBuilder();
-        final Properties props = ConfigUtil.toProperties(kafkaConfig.getConfig("streams"));
+        final Properties props = ConfigUtil.toProperties(appConfig.getConfig(STREAMS));
         final StreamsConfig streamsConfig = new StreamsConfig(props);
-        final String topic = kafkaConfig.getString("topic");
-        return new StreamsFactory(builder::build, streamsConfig, topic);
+        final String inboundTopic = appConfig.getString(INBOUND_TOPIC);
+        return new StreamsFactory(builder::build, streamsConfig, inboundTopic);
     }
     
     private StateChangeListener healthListener() {
         final HealthStatusController controller = new HealthStatusController();
-        final String path = kafkaConfig.getString("health.status.path");
+        final String path = appConfig.getString(HEALTH_STATUS_PATH);
         controller.addListener(new UpdateHealthStatusFile(path));
         return new StateChangeListener(controller);
     }

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/KafkaConfigProps.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/KafkaConfigProps.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.kafka;
+
+/**
+ * Contains standard app names and config properties. "Standard" here means that all (or at least most) Kafka-based AA
+ * deployments use them. Properties that appear in multiple places in the codebase have priority, for DRY purposes.
+ *
+ * @author Willie Wheeler
+ */
+public interface KafkaConfigProps {
+    
+    
+    // ================================================================================
+    // App names
+    // ================================================================================
+    
+    /**
+     * Metric Router KStreams app name.
+     */
+    public static final String METRIC_ROUTER = "metric-router";
+    
+    /**
+     * Anomaly Detector Manager KStreams app name.
+     */
+    public static final String ANOMALY_DETECTOR_MANAGER = "anomaly-detector-manager";
+    
+    /**
+     * Anomaly Validator KStreams app name.
+     */
+    public static final String ANOMALY_VALIDATOR = "anomaly-validator";
+    
+    
+    // ================================================================================
+    // App config properties
+    // ================================================================================
+    
+    /**
+     * Factories property name.
+     */
+    public static final String FACTORIES = "factories";
+    
+    /**
+     * Streams property name.
+     */
+    public static final String STREAMS = "streams";
+    
+    /**
+     * Health status path property name.
+     */
+    public static final String HEALTH_STATUS_PATH = "health.status.path";
+    
+    /**
+     * Inbound topic property name.
+     */
+    public static final String INBOUND_TOPIC = "inbound-topic";
+    
+    /**
+     * Outbound topic property name.
+     */
+    public static final String OUTBOUND_TOPIC = "outbound-topic";
+    
+    /**
+     * JSON POJO class property name.
+     */
+    public static final String JSON_POJO_CLASS = "JsonPojoClass";
+}

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaAnomalyDetectorManager.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaAnomalyDetectorManager.java
@@ -15,12 +15,15 @@
  */
 package com.expedia.adaptivealerting.kafka.detector;
 
+import com.expedia.adaptivealerting.anomdetect.AnomalyDetectorFactory;
 import com.expedia.adaptivealerting.anomdetect.AnomalyDetectorManager;
 import com.expedia.adaptivealerting.core.data.MappedMpoint;
 import com.expedia.adaptivealerting.kafka.AbstractKafkaApp;
 import com.expedia.adaptivealerting.kafka.serde.JsonPojoDeserializer;
 import com.expedia.adaptivealerting.kafka.serde.JsonPojoSerializer;
 import com.expedia.adaptivealerting.kafka.serde.MpointTimestampExtractor;
+import com.expedia.adaptivealerting.kafka.util.AppUtil;
+import com.expedia.adaptivealerting.kafka.util.ReflectionUtil;
 import com.typesafe.config.Config;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.Consumed;
@@ -34,6 +37,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
+import static com.expedia.adaptivealerting.kafka.KafkaConfigProps.*;
 
 /**
  * Kafka wrapper around {@link AnomalyDetectorManager}.
@@ -42,14 +46,17 @@ import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
  * @author Willie Wheeler
  */
 public final class KafkaAnomalyDetectorManager extends AbstractKafkaApp {
-    
-    // TODO Externalize this to the Kafka config. [WLW]
-    private static final String ANOMALY_TOPIC = "anomalies";
-    
     private AnomalyDetectorManager manager;
     
-    public KafkaAnomalyDetectorManager(Config kafkaConfig, AnomalyDetectorManager manager) {
-        super(kafkaConfig);
+    public static void main(String[] args) {
+        final Config appConfig = AppUtil.getAppConfig(ANOMALY_DETECTOR_MANAGER);
+        final AnomalyDetectorManager manager =
+                new AnomalyDetectorManager(detectorFactories(appConfig.getConfig(FACTORIES)));
+        new KafkaAnomalyDetectorManager(appConfig, manager).start();
+    }
+    
+    public KafkaAnomalyDetectorManager(Config appConfig, AnomalyDetectorManager manager) {
+        super(appConfig);
         notNull(manager, "manager can't be null");
         this.manager = manager;
     }
@@ -57,18 +64,28 @@ public final class KafkaAnomalyDetectorManager extends AbstractKafkaApp {
     @Override
     protected StreamsBuilder streamsBuilder() {
         final StreamsBuilder builder = new StreamsBuilder();
-        final String topic = getKafkaConfig().getString("topic");
-        final KStream<String, MappedMpoint> stream = builder.stream(topic, jsonMpointSerde());
+        final String inboundTopic = getAppConfig().getString(INBOUND_TOPIC);
+        final String outboundTopic = getAppConfig().getString(OUTBOUND_TOPIC);
+        final KStream<String, MappedMpoint> stream = builder.stream(inboundTopic, jsonMpointSerde());
         stream
                 .map((key, mappedMpoint) -> KeyValue.pair(key, manager.classify(mappedMpoint)))
-                .to(ANOMALY_TOPIC, jsonAnomalySerde());
+                .to(outboundTopic, jsonAnomalySerde());
         return builder;
+    }
+    
+    private static Map<String, AnomalyDetectorFactory> detectorFactories(Config appConfig) {
+        final Map<String, AnomalyDetectorFactory> factories = new HashMap<>();
+        appConfig.entrySet().forEach(entry -> {
+            final String factoryClassName = entry.getValue().unwrapped().toString();
+            factories.put(entry.getKey(), (AnomalyDetectorFactory) ReflectionUtil.newInstance(factoryClassName));
+        });
+        return factories;
     }
     
     private Consumed<String, MappedMpoint> jsonMpointSerde() {
         final JsonPojoDeserializer<MappedMpoint> deserializer = new JsonPojoDeserializer<>();
         final Map<String, Object> props = new HashMap<>();
-        props.put("JsonPojoClass", MappedMpoint.class);
+        props.put(JSON_POJO_CLASS, MappedMpoint.class);
         deserializer.configure(props, false);
         
         return Consumed.with(

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaAnomalyDetectorManager.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaAnomalyDetectorManager.java
@@ -76,8 +76,10 @@ public final class KafkaAnomalyDetectorManager extends AbstractKafkaApp {
     private static Map<String, AnomalyDetectorFactory> detectorFactories(Config appConfig) {
         final Map<String, AnomalyDetectorFactory> factories = new HashMap<>();
         appConfig.entrySet().forEach(entry -> {
-            final String factoryClassName = entry.getValue().unwrapped().toString();
-            factories.put(entry.getKey(), (AnomalyDetectorFactory) ReflectionUtil.newInstance(factoryClassName));
+            final String className = entry.getValue().unwrapped().toString();
+            final AnomalyDetectorFactory factory = (AnomalyDetectorFactory) ReflectionUtil.newInstance(className);
+            factory.init(appConfig);
+            factories.put(entry.getKey(), factory);
         });
         return factories;
     }

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaConstantThresholdOutlierDetector.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaConstantThresholdOutlierDetector.java
@@ -24,10 +24,13 @@ import com.typesafe.config.Config;
 import org.apache.kafka.streams.StreamsBuilder;
 
 import static com.expedia.adaptivealerting.anomdetect.ConstantThresholdAnomalyDetector.RIGHT_TAILED;
+import static com.expedia.adaptivealerting.kafka.KafkaConfigProps.INBOUND_TOPIC;
 
-// TODO Rename to KafkaConstantThresholdAnomalyDetector. [WLW]
-
-public class KafkaConstantThresholdOutlierDetector {
+/**
+ * @deprecated Use KafkaAnomalyDetectorManager instead.
+ */
+@Deprecated
+public final class KafkaConstantThresholdOutlierDetector {
 
     public static void main(String[] args) {
         Config appConfig = AppUtil.getAppConfig("constant-detector");
@@ -38,7 +41,7 @@ public class KafkaConstantThresholdOutlierDetector {
         @Override
         public StreamsRunner build(Config appConfig) {
             final StreamsBuilder builder = DetectorUtil.createDetectorStreamsBuilder(
-                appConfig.getString("topic"),
+                appConfig.getString(INBOUND_TOPIC),
                 id -> new ConstantThresholdAnomalyDetector(RIGHT_TAILED, 0.99f, 0.95f)
             );
 

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaEwmaOutlierDetector.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaEwmaOutlierDetector.java
@@ -23,14 +23,18 @@ import com.expedia.www.haystack.commons.kstreams.app.StreamsRunner;
 import com.typesafe.config.Config;
 import org.apache.kafka.streams.StreamsBuilder;
 
+import static com.expedia.adaptivealerting.kafka.KafkaConfigProps.INBOUND_TOPIC;
+
 // TODO Rename to KafkaEwmaAnomalyDetector. [WLW]
 
 /**
  * Kafka Streams application for the EWMA outlier detector.
  *
  * @author Willie Wheeler
+ * @deprecated Use KafkaAnomalyDetectorManager instead.
  */
-public class KafkaEwmaOutlierDetector {
+@Deprecated
+public final class KafkaEwmaOutlierDetector {
 
     public static void main(String[] args) {
         Config appConfig = AppUtil.getAppConfig("ewma-detector");
@@ -41,8 +45,8 @@ public class KafkaEwmaOutlierDetector {
         @Override
         public StreamsRunner build(Config appConfig) {
             final StreamsBuilder builder = DetectorUtil.createDetectorStreamsBuilder(
-                appConfig.getString("topic"),
-                id -> new EwmaAnomalyDetector(0.8, 3.0, 2.0, 100.0)
+                appConfig.getString(INBOUND_TOPIC),
+                id -> new EwmaAnomalyDetector(0.8, 3.0, 4.0, 100.0)
             );
             return createStreamsRunner(appConfig, builder);
         }

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaPewmaOutlierDetector.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaPewmaOutlierDetector.java
@@ -23,14 +23,17 @@ import com.expedia.www.haystack.commons.kstreams.app.StreamsRunner;
 import com.typesafe.config.Config;
 import org.apache.kafka.streams.StreamsBuilder;
 
+import static com.expedia.adaptivealerting.kafka.KafkaConfigProps.INBOUND_TOPIC;
+
 // TODO Rename to KafkaPewmaAnomalyDetector. [WLW]
 
 /**
  * Kafka Streams application for the PEWMA outlier detector.
  *
  * @author David Sutherland
+ * @deprecated Use KafkaAnomalyDetectorManager instead.
  */
-public class KafkaPewmaOutlierDetector {
+public final class KafkaPewmaOutlierDetector {
 
     public static void main(String[] args) {
         Config appConfig = AppUtil.getAppConfig("pewma-detector");
@@ -41,8 +44,8 @@ public class KafkaPewmaOutlierDetector {
         @Override
         public StreamsRunner build(Config appConfig) {
             final StreamsBuilder builder = DetectorUtil.createDetectorStreamsBuilder(
-                appConfig.getString("topic"),
-                id -> new PewmaAnomalyDetector(0.05, 1.0, 2.0, 3.0, 100.0)
+                appConfig.getString(INBOUND_TOPIC),
+                id -> new PewmaAnomalyDetector(0.05, 1.0, 3.0, 4.0, 100.0)
             );
 
             return createStreamsRunner(appConfig, builder);

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/serde/AnomalyResultTimeStampExtractor.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/serde/AnomalyResultTimeStampExtractor.java
@@ -24,6 +24,7 @@ import org.apache.kafka.streams.processor.TimestampExtractor;
  * similar to class {@link org.apache.kafka.streams.processor.LogAndSkipOnInvalidTimestamp}
  * adding this as com.expedia.www.haystack.commons.kstreams.MetricPointTimestampExtractor doesn't handle this
  */
+// TODO Rename to AnomalyResultTimestampExtractor [WLW]
 public class AnomalyResultTimeStampExtractor implements TimestampExtractor {
 
     @Override

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/serde/HaystackMetricTimeStampExtractor.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/serde/HaystackMetricTimeStampExtractor.java
@@ -25,7 +25,7 @@ import org.apache.kafka.streams.processor.TimestampExtractor;
  * adding this as com.expedia.www.haystack.commons.kstreams.MetricPointTimestampExtractor doesn't handle this
  *
  * @author shsethi
- * @deprecated Deprecated in favor of {@link MpointTimestampExtractor}.
+ * @deprecated Deprecated in favor of {@link MappedMpointTimestampExtractor}.
  */
 @Deprecated
 public class HaystackMetricTimeStampExtractor implements TimestampExtractor {

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/serde/MappedMpointTimestampExtractor.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/serde/MappedMpointTimestampExtractor.java
@@ -15,6 +15,7 @@
  */
 package com.expedia.adaptivealerting.kafka.serde;
 
+import com.expedia.adaptivealerting.core.data.MappedMpoint;
 import com.expedia.adaptivealerting.core.data.Mpoint;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.streams.processor.TimestampExtractor;
@@ -29,18 +30,21 @@ import org.slf4j.LoggerFactory;
  * @author Shubham Sethi
  * @author Willie Wheeler
  */
-public class MpointTimestampExtractor implements TimestampExtractor {
-    private static final Logger log = LoggerFactory.getLogger(MpointTimestampExtractor.class);
+public class MappedMpointTimestampExtractor implements TimestampExtractor {
+    private static final Logger log = LoggerFactory.getLogger(MappedMpointTimestampExtractor.class);
     
     @Override
     public long extract(ConsumerRecord<Object, Object> record, long previousTimestamp) {
-        Mpoint mpoint = (Mpoint) record.value();
-        if (mpoint == null) {
+        final MappedMpoint mappedMpoint = (MappedMpoint) record.value();
+        if (mappedMpoint == null || mappedMpoint.getMpoint() == null) {
+            
+            // We don't want to log this because sometimes it fills up the logs.
+            // TODO Figure out what to do instead. Maybe a counter.
+//            log.warn("Skipping null MappedMpoint");
+            
             // -1 skips the record.
-            log.warn("Skipping null Mpoint");
             return -1L;
         }
-        
-        return mpoint.getEpochTimeInSeconds() * 1000L;
+        return mappedMpoint.getMpoint().getEpochTimeInSeconds() * 1000L;
     }
 }

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/util/BaseStreamRunnerBuilder.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/util/BaseStreamRunnerBuilder.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 
 import static com.expedia.adaptivealerting.kafka.KafkaConfigProps.HEALTH_STATUS_PATH;
 import static com.expedia.adaptivealerting.kafka.KafkaConfigProps.INBOUND_TOPIC;
+import static com.expedia.adaptivealerting.kafka.KafkaConfigProps.STREAMS;
 
 /**
  * @deprecated Deprecated in favor of {@link com.expedia.adaptivealerting.kafka.AbstractKafkaApp}.
@@ -45,7 +46,7 @@ public abstract class BaseStreamRunnerBuilder {
 
         StateChangeListener stateChangeListener = new StateChangeListener(healthStatusController);
 
-        StreamsConfig streamsConfig = new StreamsConfig(configToProp(appConfig.getConfig("streams")));
+        StreamsConfig streamsConfig = new StreamsConfig(configToProp(appConfig.getConfig(STREAMS)));
 
         StreamsFactory streamsFactory = new StreamsFactory(builder::build, streamsConfig, topic);
 

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/util/BaseStreamRunnerBuilder.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/util/BaseStreamRunnerBuilder.java
@@ -26,6 +26,9 @@ import org.apache.kafka.streams.StreamsConfig;
 
 import java.util.Properties;
 
+import static com.expedia.adaptivealerting.kafka.KafkaConfigProps.HEALTH_STATUS_PATH;
+import static com.expedia.adaptivealerting.kafka.KafkaConfigProps.INBOUND_TOPIC;
+
 /**
  * @deprecated Deprecated in favor of {@link com.expedia.adaptivealerting.kafka.AbstractKafkaApp}.
  */
@@ -34,8 +37,8 @@ public abstract class BaseStreamRunnerBuilder {
     public abstract StreamsRunner build(Config config);
 
     protected StreamsRunner createStreamsRunner(Config appConfig, StreamsBuilder builder) {
-        String healthStatusPath = appConfig.getString("health.status.path");
-        String topic = appConfig.getString("topic");
+        String healthStatusPath = appConfig.getString(HEALTH_STATUS_PATH);
+        String topic = appConfig.getString(INBOUND_TOPIC);
 
         HealthStatusController healthStatusController = new HealthStatusController();
         healthStatusController.addListener(new UpdateHealthStatusFile(healthStatusPath));

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/util/ReflectionUtil.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/util/ReflectionUtil.java
@@ -13,28 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.expedia.adaptivealerting.anomdetect;
+package com.expedia.adaptivealerting.kafka.util;
 
-import com.typesafe.config.Config;
-
-import java.util.UUID;
+import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
 
 /**
- * Anomaly detector factory.
- *
  * @author Willie Wheeler
  */
-public interface AnomalyDetectorFactory<T extends AnomalyDetector> {
-    
-    void init(Config config);
+public final class ReflectionUtil {
     
     /**
-     * Creates an anomaly detector. This would usually involve looking up at least the model parameters from persistent
-     * storages, based on automated model selection and autotuning. In many cases it would involve looking up a
-     * pretrained model.
-     *
-     * @param uuid Detector UUID.
-     * @return Anomaly detector.
+     * Prevent instantiation.
      */
-    T create(UUID uuid);
+    private ReflectionUtil() {
+    }
+    
+    public static Object newInstance(String className) {
+        notNull(className, "className can't be null");
+        try {
+            return Class.forName(className).newInstance();
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/kafka/src/main/resources/config/base.conf
+++ b/kafka/src/main/resources/config/base.conf
@@ -12,28 +12,26 @@ metric-router {
   streams {
     application.id = "metric-router"
   }
-  topic = "metrics"
+  inbound-topic = "metrics"
+
+  # TODO This doesn't do anything yet, but it will once MetricRouter maps the mpoints. [WLW]
+  outbound-topic = "mapped-metrics"
 }
 
-constant-detector {
+anomaly-detector-manager {
   streams {
-    application.id = "constant-detector"
+    application.id = "anomaly-detector-manager"
+    default.value.serde = "com.expedia.adaptivealerting.kafka.serde.JsonPojoSerde"
   }
-  topic = "constant-metrics"
-}
-
-ewma-detector {
-  streams {
-    application.id = "ewma-detector"
+  factories {
+    constant-detector = "com.expedia.adaptivealerting.anomdetect.ConstantThresholdAnomalyDetectorFactory"
+    cusum-detector = "com.expedia.adaptivealerting.anomdetect.CusumAnomalyDetectorFactory"
+    ewma-detector = "com.expedia.adaptivealerting.anomdetect.EwmaAnomalyDetectorFactory"
+    pewma-detector = "com.expedia.adaptivealerting.anomdetect.PewmaAnomalyDetectorFactory"
+    rcf-detector = "com.expedia.adaptivealerting.anomdetect.randomcutforest.RandomCutForestAnomalyDetectorFactory"
   }
-  topic = "ewma-metrics"
-}
-
-pewma-detector {
-  streams {
-    application.id = "pewma-detector"
-  }
-  topic = "pewma-metrics"
+  inbound-topic = "mapped-metrics"
+  outbound-topic = "anomalies"
 }
 
 anomaly-validator {
@@ -43,5 +41,35 @@ anomaly-validator {
     JsonPojoClass = "com.expedia.adaptivealerting.core.anomaly.AnomalyResult"
     default.timestamp.extractor = "com.expedia.adaptivealerting.kafka.serde.AnomalyResultTimeStampExtractor"
   }
-  topic = "anomalies"
+  inbound-topic = "anomalies"
+  outbound-topic = "alerts"
+}
+
+# ================================================================================
+# Deprecated stuff
+#
+# These individual anomaly detector applications will go away. The
+# anomaly-detector-manager app above takes over the Kafka app responsibility, and
+# the individual detectors are just components that run inside the manager. [WLW]
+# ================================================================================
+
+constant-detector {
+  streams {
+    application.id = "constant-detector"
+  }
+  inbound-topic = "constant-metrics"
+}
+
+ewma-detector {
+  streams {
+    application.id = "ewma-detector"
+  }
+  inbound-topic = "ewma-metrics"
+}
+
+pewma-detector {
+  streams {
+    application.id = "pewma-detector"
+  }
+  inbound-topic = "pewma-metrics"
 }

--- a/kafka/src/main/resources/config/base.conf
+++ b/kafka/src/main/resources/config/base.conf
@@ -22,6 +22,8 @@ anomaly-detector-manager {
   streams {
     application.id = "anomaly-detector-manager"
     default.value.serde = "com.expedia.adaptivealerting.kafka.serde.JsonPojoSerde"
+    JsonPojoClass = "com.expedia.adaptivealerting.core.data.MappedMpoint"
+    default.timestamp.extractor = "com.expedia.adaptivealerting.kafka.serde.MappedMpointTimestampExtractor"
   }
   factories {
     constant-detector = "com.expedia.adaptivealerting.anomdetect.ConstantThresholdAnomalyDetectorFactory"
@@ -31,7 +33,9 @@ anomaly-detector-manager {
     rcf-detector = "com.expedia.adaptivealerting.anomdetect.randomcutforest.RandomCutForestAnomalyDetectorFactory"
   }
   inbound-topic = "mapped-metrics"
-  outbound-topic = "anomalies"
+
+  # TODO Make this "anomalies" once we are pushing MappedMpoints to the anomalies topic. [WLW]
+  outbound-topic = "anomalies-temp"
 }
 
 anomaly-validator {


### PR DESCRIPTION
The KADM needs to be able to create detectors on demand. To do this we use
the factory pattern. When the KADM starts up, it needs to know the mapping
from detector names to factory classnames. Hence the number of factory-
related classes in this commit.

In the future we want to get rid of the detector-specific KStreams apps
and just use the KADM to host detectors. But for now the system works with
detector-specific apps and I didn't want to break that. So that's all left
alone. As part of the KADM implementation, though, I did externalize the
names of the inbound and outbound topics to config files, and I did this
using the configuration property names inbound-topic and outbound-topic.
To avoid having to handle both "topic" (the old name for the inbound
topic) and "inbound-topic", I just migrated everything over to using the
"inbound-topic" name, and switch the property names over to constants to
establish better control. I've updated the Haystack Terraform to define
both "topic" and "inbound-topic" values for now. Once this AA update is
deployed, we can remove the "topic" definitions from the Haystack
Terraform.

This change also fixes the bad default settings for the EWMA and PEWMA
detectors. EWMA had reversed weak/strong thresholds, and both had settings
that were too aggressive. (Instead of weak/strong of 2/3, I used 3/4. Two
sigmas is way too aggressive for alerting.)