### PR TITLE
Created a new AnomalyDetectorMapper, intended to replace MetricRouter.

### DIFF
--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetectorMapper.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetectorMapper.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.anomdetect;
+
+import com.expedia.adaptivealerting.core.data.MappedMpoint;
+import com.expedia.adaptivealerting.core.data.Metric;
+import com.expedia.adaptivealerting.core.data.Mpoint;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
+
+/**
+ * Entry into the Adaptive Alerting runtime. Its job is find for any incoming {@link Mpoint} its set of mapped
+ * detectors, creating the corresponding {@link MappedMpoint}s.
+ *
+ * @author David Sutherland
+ * @author Willie Wheeler
+ */
+public final class AnomalyDetectorMapper {
+    
+    /**
+     * Maps an {@link Mpoint} to its corresponding set of {@link MappedMpoint}s.
+     *
+     * @param mpoint Mpoint to map.
+     * @return The corresponding set of {@link MappedMpoint}s: one per detector.
+     */
+    public Set<MappedMpoint> map(Mpoint mpoint) {
+        notNull(mpoint, "mpoint can't be null");
+        return createMappedMpoints(mpoint, findDetectors(mpoint.getMetric()));
+    }
+    
+    private Set<DetectorMeta> findDetectors(Metric metric) {
+        
+        // TODO Resolve mappings using the model service instead of the following hardcoded logic. For now, only
+        // bookings metrics get through. We can generalize/fix this when we switch over to using Mpoints generally.
+        final Map<String, String> tags = metric.getTags();
+        final Set<DetectorMeta> results = new HashSet<>();
+        if ("bookings".equals(tags.get("what"))) {
+            results.add(new DetectorMeta(UUID.fromString("636e13ed-6882-48cc-be75-56986a3b0179"), "aquila-detector"));
+        }
+        return results;
+    }
+    
+    private Set<MappedMpoint> createMappedMpoints(Mpoint mpoint, Set<DetectorMeta> detectors) {
+        return detectors.stream()
+                .map(detector -> new MappedMpoint(mpoint, detector.getUuid(), detector.getType()))
+                .collect(Collectors.toSet());
+    }
+    
+    private static class DetectorMeta {
+        private UUID uuid;
+        private String type;
+    
+        public DetectorMeta(UUID uuid, String type) {
+            this.uuid = uuid;
+            this.type = type;
+        }
+    
+        public UUID getUuid() {
+            return uuid;
+        }
+    
+        public String getType() {
+            return type;
+        }
+    }
+}

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetectorMapperTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetectorMapperTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.anomdetect;
+
+import com.expedia.adaptivealerting.core.data.MappedMpoint;
+import com.expedia.adaptivealerting.core.data.Metric;
+import com.expedia.adaptivealerting.core.data.Mpoint;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * @author Willie Wheeler
+ */
+public final class AnomalyDetectorMapperTest {
+    
+    // Class under test
+    private AnomalyDetectorMapper mapper;
+    
+    // Test objects
+    private Mpoint mpointWithDetectors;
+    private Mpoint mpointWithoutDetectors;
+    
+    @Before
+    public void setUp() {
+        this.mapper = new AnomalyDetectorMapper();
+        
+        // TODO For now, this is known to have detectors.
+        // We'll need to update this once we un-hardcode the AnomalyDetectorMapper.
+        final Metric metricWithDetectors = new Metric();
+        metricWithDetectors.putTag("what", "bookings");
+        this.mpointWithDetectors = new Mpoint();
+        mpointWithDetectors.setMetric(metricWithDetectors);
+        
+        // TODO For now, this is known to have no detectors. See above.
+        final Metric metricWithoutDetectors = new Metric();
+        this.mpointWithoutDetectors = new Mpoint();
+        mpointWithoutDetectors.setMetric(metricWithoutDetectors);
+    }
+    
+    @Test
+    public void testMap_mpointWithDetectors() {
+        final Set<MappedMpoint> results = mapper.map(mpointWithDetectors);
+        assertFalse(results.isEmpty());
+    }
+    
+    @Test
+    public void testMap_mpointWithoutDetectors() {
+        final Set<MappedMpoint> results = mapper.map(mpointWithoutDetectors);
+        assertTrue(results.isEmpty());
+    }
+}

--- a/core/src/main/java/com/expedia/adaptivealerting/core/data/MappedMpoint.java
+++ b/core/src/main/java/com/expedia/adaptivealerting/core/data/MappedMpoint.java
@@ -19,6 +19,8 @@ import com.expedia.adaptivealerting.core.anomaly.AnomalyResult;
 
 import java.util.UUID;
 
+import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
+
 /**
  * <p>
  * Wraps an endpoint with a representation that includes anomaly detection information.
@@ -34,6 +36,21 @@ public final class MappedMpoint {
     private UUID detectorUuid;
     private String detectorType;
     private AnomalyResult anomalyResult;
+    
+    /**
+     * To support serialization.
+     */
+    public MappedMpoint() {
+    }
+    
+    public MappedMpoint(Mpoint mpoint, UUID detectorUuid, String detectorType) {
+        notNull(mpoint, "mpoint can't be null");
+        notNull(detectorUuid, "detectorUuid can't be null");
+        notNull(detectorType, "detectorType can't be null");
+        this.mpoint = mpoint;
+        this.detectorUuid = detectorUuid;
+        this.detectorType = detectorType;
+    }
     
     public Mpoint getMpoint() {
         return mpoint;

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/KafkaConfigProps.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/KafkaConfigProps.java
@@ -29,8 +29,14 @@ public interface KafkaConfigProps {
     // ================================================================================
     
     /**
+     * Anomaly Detector Mapper KStreams app name.
+     */
+    public static final String ANOMALY_DETECTOR_MAPPER = "anomaly-detector-mapper";
+    
+    /**
      * Metric Router KStreams app name.
      */
+    @Deprecated
     public static final String METRIC_ROUTER = "metric-router";
     
     /**

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaAnomalyDetectorManager.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/detector/KafkaAnomalyDetectorManager.java
@@ -22,7 +22,6 @@ import com.expedia.adaptivealerting.kafka.AbstractKafkaApp;
 import com.expedia.adaptivealerting.kafka.util.AppUtil;
 import com.expedia.adaptivealerting.kafka.util.ReflectionUtil;
 import com.typesafe.config.Config;
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.KStream;
 
@@ -61,7 +60,7 @@ public final class KafkaAnomalyDetectorManager extends AbstractKafkaApp {
         final String outboundTopic = getAppConfig().getString(OUTBOUND_TOPIC);
         final KStream<String, MappedMpoint> stream = builder.stream(inboundTopic);
         stream
-                .map((key, mappedMpoint) -> KeyValue.pair(key, manager.classify(mappedMpoint)))
+                .mapValues(mappedMpoint -> manager.classify(mappedMpoint))
                 .to(outboundTopic);
         return builder;
     }

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/mapper/KafkaAnomalyDetectorMapper.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/mapper/KafkaAnomalyDetectorMapper.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.kafka.mapper;
+
+import com.expedia.adaptivealerting.anomdetect.AnomalyDetectorMapper;
+import com.expedia.adaptivealerting.core.data.MappedMpoint;
+import com.expedia.adaptivealerting.core.data.Mpoint;
+import com.expedia.adaptivealerting.kafka.AbstractKafkaApp;
+import com.expedia.adaptivealerting.kafka.util.AppUtil;
+import com.typesafe.config.Config;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.KStream;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
+import static com.expedia.adaptivealerting.kafka.KafkaConfigProps.*;
+
+/**
+ * Kafka wrapper around {@link AnomalyDetectorMapper}.
+ *
+ * @author David Sutherland
+ * @author Willie Wheeler
+ */
+public final class KafkaAnomalyDetectorMapper extends AbstractKafkaApp {
+    private AnomalyDetectorMapper mapper;
+    
+    public static void main(String[] args) {
+        final Config appConfig = AppUtil.getAppConfig(ANOMALY_DETECTOR_MAPPER);
+        new KafkaAnomalyDetectorMapper(appConfig, new AnomalyDetectorMapper()).start();
+    }
+    
+    public KafkaAnomalyDetectorMapper(Config appConfig, AnomalyDetectorMapper mapper) {
+        super(appConfig);
+        notNull(mapper, "mapper can't be null");
+        this.mapper = mapper;
+    }
+    
+    @Override
+    protected StreamsBuilder streamsBuilder() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final String inboundTopic = getAppConfig().getString(INBOUND_TOPIC);
+        final String outboundTopic = getAppConfig().getString(OUTBOUND_TOPIC);
+        final KStream<String, Mpoint> stream = builder.stream(inboundTopic);
+        
+        // This approach forces all detectors for a given metric to reside with a given manager.
+//        stream
+//                .flatMapValues(mpoint -> mapper.map(mpoint))
+//                .to(outboundTopic);
+        
+        // This approach allows us to distribute detectors for a given metric across managers.
+        stream
+                .flatMap((key, mpoint) -> {
+                        
+                            // Convert the <key, mpoint> pair into a set of <detectorUuid, mappedMpoint> pairs.
+                            // Each detector UUID comes from its mapped mpoint.
+                            final Set<MappedMpoint> mappedMpoints = mapper.map(mpoint);
+                            return mappedMpoints.stream()
+                                    .map(mappedMpoint -> {
+                                        final String newKey = mappedMpoint.getDetectorUuid().toString();
+                                        return KeyValue.pair(newKey, mappedMpoint);
+                                    })
+                                    .collect(Collectors.toSet());
+                        }
+                )
+                .to(outboundTopic);
+    
+        return builder;
+    }
+}

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/router/MetricRouter.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/router/MetricRouter.java
@@ -27,7 +27,10 @@ import static com.expedia.adaptivealerting.kafka.KafkaConfigProps.INBOUND_TOPIC;
 import static com.expedia.adaptivealerting.kafka.KafkaConfigProps.METRIC_ROUTER;
 import static com.expedia.adaptivealerting.kafka.KafkaConfigProps.OUTBOUND_TOPIC;
 
-// TODO Isolate the infrastructure-independent logic. [WLW]
+/**
+ * @deprecated Use {@link com.expedia.adaptivealerting.kafka.mapper.KafkaAnomalyDetectorMapper} instead.
+ */
+@Deprecated
 public final class MetricRouter {
 
     public static void main(String[] args) {

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/serde/MpointTimestampExtractor.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/serde/MpointTimestampExtractor.java
@@ -15,33 +15,28 @@
  */
 package com.expedia.adaptivealerting.kafka.serde;
 
-import com.expedia.adaptivealerting.core.data.MappedMpoint;
 import com.expedia.adaptivealerting.core.data.Mpoint;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.streams.processor.TimestampExtractor;
 
 /**
- * Timestamp extractor for {@link Mpoint}, similar to
- * {@link org.apache.kafka.streams.processor.LogAndSkipOnInvalidTimestamp}.
- * Adding this as com.expedia.www.haystack.commons.kstreams.MetricPointTimestampExtractor doesn't handle null values.
- *
  * @author Shubham Sethi
  * @author Willie Wheeler
  */
-public final class MappedMpointTimestampExtractor implements TimestampExtractor {
+public final class MpointTimestampExtractor implements TimestampExtractor {
     
     @Override
     public long extract(ConsumerRecord<Object, Object> record, long previousTimestamp) {
-        final MappedMpoint mappedMpoint = (MappedMpoint) record.value();
-        if (mappedMpoint == null || mappedMpoint.getMpoint() == null) {
+        final Mpoint mpoint = (Mpoint) record.value();
+        if (mpoint == null) {
             
             // We don't want to log this because sometimes it fills up the logs.
             // TODO Figure out what to do instead. Maybe a counter.
-//            log.warn("Skipping null MappedMpoint");
+//            log.warn("Skipping null Mpoint");
             
             // -1 skips the record.
             return -1L;
         }
-        return mappedMpoint.getMpoint().getEpochTimeInSeconds() * 1000L;
+        return mpoint.getEpochTimeInSeconds() * 1000L;
     }
 }

--- a/kafka/src/main/resources/config/base.conf
+++ b/kafka/src/main/resources/config/base.conf
@@ -4,18 +4,21 @@ kstream.app.default {
     auto.offset.reset = "latest"
     default.key.serde = "org.apache.kafka.common.serialization.Serdes$StringSerde"
     default.value.serde = "com.expedia.www.haystack.commons.kstreams.serde.metricpoint.MetricTankSerde"
-    default.timestamp.extractor="com.expedia.adaptivealerting.kafka.serde.HaystackMetricTimeStampExtractor"
+    default.timestamp.extractor = "com.expedia.adaptivealerting.kafka.serde.HaystackMetricTimeStampExtractor"
   }
   health.status.path = "/app/isHealthy"
 }
 
-metric-router {
+anomaly-detector-mapper {
   streams {
-    application.id = "metric-router"
+    application.id = "anomaly-detector-mapper"
+    default.value.serde = "com.expedia.adaptivealerting.kafka.serde.JsonPojoSerde"
+    JsonPojoClass = "com.expedia.adaptivealerting.core.data.Mpoint"
+    default.timestamp.extractor = "com.expedia.adaptivealerting.kafka.serde.MpointTimestampExtractor"
   }
-  inbound-topic = "metrics"
 
-  # TODO This doesn't do anything yet, but it will once MetricRouter maps the mpoints. [WLW]
+  # TODO Update "metrics-temp" to "metrics" [WLW]
+  inbound-topic = "metrics-temp"
   outbound-topic = "mapped-metrics"
 }
 
@@ -33,9 +36,9 @@ anomaly-detector-manager {
     pewma-detector = "com.expedia.adaptivealerting.anomdetect.PewmaAnomalyDetectorFactory"
     rcf-detector = "com.expedia.adaptivealerting.anomdetect.randomcutforest.RandomCutForestAnomalyDetectorFactory"
   }
-  inbound-topic = "mapped-metrics"
 
-  # TODO Make this "anomalies" once we are pushing MappedMpoints to the anomalies topic. [WLW]
+  # TODO Update "anomalies-temp" to "anomalies" [WLW]
+  inbound-topic = "mapped-metrics"
   outbound-topic = "anomalies-temp"
 }
 
@@ -57,6 +60,16 @@ anomaly-validator {
 # anomaly-detector-manager app above takes over the Kafka app responsibility, and
 # the individual detectors are just components that run inside the manager. [WLW]
 # ================================================================================
+
+metric-router {
+  streams {
+    application.id = "metric-router"
+  }
+  inbound-topic = "metrics"
+
+  # TODO This doesn't do anything yet, but it will once MetricRouter maps the mpoints. [WLW]
+  outbound-topic = "mapped-metrics"
+}
 
 constant-detector {
   streams {


### PR DESCRIPTION
MetricRouter is deprecated primarily because the "routing" function is no
longer routing as much as it is message splitting and enrichment. But
there were some other things we needed to take care of anyway. The new
AnomalyDetectorMapper takes care of these:

- Separates the core mapping logic (i.e. the splitting/enrichment) from
  the Kafka wrapper
- Consumes Mpoints instead of Haystack MetricPoints
- Produces MappedMpoints instead of Haystack MetricPoints