### PR TITLE
Can now handle missing detectors.

### DIFF
--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetectorManager.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetectorManager.java
@@ -16,6 +16,10 @@
 package com.expedia.adaptivealerting.anomdetect;
 
 import com.expedia.adaptivealerting.core.data.MappedMpoint;
+import com.expedia.adaptivealerting.core.util.ReflectionUtil;
+import com.typesafe.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,6 +34,7 @@ import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
  * @author Willie Wheeler
  */
 public final class AnomalyDetectorManager {
+    private static final Logger log = LoggerFactory.getLogger(AnomalyDetectorManager.class);
     
     /**
      * Factories that know how to produce anomaly detectors on demand.
@@ -40,6 +45,17 @@ public final class AnomalyDetectorManager {
      * The managed detectors.
      */
     private final Map<UUID, AnomalyDetector> detectors = new HashMap<>();
+    
+    public AnomalyDetectorManager(Config factoryConfig) {
+        notNull(factoryConfig, "factoryConfig can't be null");
+        this.detectorFactories = new HashMap<>();
+        factoryConfig.entrySet().forEach(entry -> {
+            final String className = entry.getValue().unwrapped().toString();
+            final AnomalyDetectorFactory factory = (AnomalyDetectorFactory) ReflectionUtil.newInstance(className);
+            factory.init(factoryConfig);
+            detectorFactories.put(entry.getKey(), factory);
+        });
+    }
     
     /**
      * Creates a new anomaly detector manager.
@@ -52,10 +68,12 @@ public final class AnomalyDetectorManager {
     }
     
     /**
-     * Gets the anomaly detector for the given metric point, creating it if absent.
+     * Gets the anomaly detector for the given metric point, creating it if absent. Returns {@code null} if there's no
+     * {@link AnomalyDetectorFactory} defined for the mapped mpoint's detector type.
      *
      * @param mappedMpoint Mapped metric point.
-     * @return Anomaly detector for the given metric point.
+     * @return Anomaly detector for the given metric point, or {@code null} if there's no registered detector factory
+     * for the mapped mpoint's detector type.
      */
     public AnomalyDetector detectorFor(MappedMpoint mappedMpoint) {
         notNull(mappedMpoint, "mappedMpoint can't be null");
@@ -64,21 +82,31 @@ public final class AnomalyDetectorManager {
         if (detector == null) {
             final String detectorType = mappedMpoint.getDetectorType();
             final AnomalyDetectorFactory factory = detectorFactories.get(detectorType);
-            detector = factory.create(detectorUuid);
-            detectors.put(detectorUuid, detector);
+            if (factory == null) {
+                log.warn("No AnomalyDetectorFactory registered for detectorType={}", detectorType);
+            } else {
+                detector = factory.create(detectorUuid);
+                detectors.put(detectorUuid, detector);
+            }
         }
         return detector;
     }
     
     /**
+     * <p>
      * Convenience method to classify the mapped metric point, performing detector lookup behind the scenes. Note that
      * this method has a side-effect in that it updates the passed mapped metric point itself.
+     * </p>
+     * <p>
+     * Returns {@code null} if there's no detector defined for the given mapped mpoint.
+     * </p>
      *
      * @param mappedMpoint Mapped metric point.
-     * @return The mapped metric point.
+     * @return The mapped metric point, or {@code null} if there's no associated detector.
      */
     public MappedMpoint classify(MappedMpoint mappedMpoint) {
         notNull(mappedMpoint, "mappedMpoint can't be null");
-        return detectorFor(mappedMpoint).classify(mappedMpoint);
+        final AnomalyDetector detector = detectorFor(mappedMpoint);
+        return detector == null ? null : detector.classify(mappedMpoint);
     }
 }

--- a/core/src/main/java/com/expedia/adaptivealerting/core/util/ReflectionUtil.java
+++ b/core/src/main/java/com/expedia/adaptivealerting/core/util/ReflectionUtil.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.expedia.adaptivealerting.kafka.util;
+package com.expedia.adaptivealerting.core.util;
 
 import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
 

--- a/kafka/run-manager.sh
+++ b/kafka/run-manager.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+mvn exec:java -Dexec.mainClass="com.expedia.adaptivealerting.kafka.detector.KafkaAnomalyDetectorManager"

--- a/kafka/run-mapper.sh
+++ b/kafka/run-mapper.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+mvn exec:java -Dexec.mainClass="com.expedia.adaptivealerting.kafka.mapper.KafkaAnomalyDetectorMapper"

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
 
         <!-- Maven plugins -->
         <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
+        <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
         <maven.jar.plugin.version>3.1.0</maven.jar.plugin.version>
     </properties>
 
@@ -232,7 +233,20 @@
                     </archive>
                 </configuration>
             </plugin>
-            <!--Plugins requried for pushing jars to public maven repository-->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${maven.exec.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Plugins required for pushing jars to public maven repository -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
Previously, if the metric point had no mapped detector, there would be a
NullPointerException, and it would crash the whole app.

Now we simply skip such metric points, logging a warning.

A couple of improvements too:

- Moved the detector factory configuration out of the Kafka ADManager into
  the core ADManager. It's not tied to Kafka so there's no reason for it
  to be in the KADManager.
- Moved the ReflectionUtil from the kafka module to the core module. Again
  it's not tied to Kafka.