### PR TITLE
Model service enhancements and fixes:

### DIFF
--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetectorMapper.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetectorMapper.java
@@ -52,7 +52,12 @@ public final class AnomalyDetectorMapper {
     }
     
     private List<AnomalyDetectorMeta> findDetectors(MetricDefinition metricDefinition) {
+        
         // TODO Replace this to call to model service. Likely want caching here as well. [WLW]
-        return new ArrayList<>();
+        final List<AnomalyDetectorMeta> metas = new ArrayList<>();
+        
+        
+        
+        return metas;
     }
 }

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetectorMapperTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetectorMapperTest.java
@@ -38,8 +38,8 @@ public final class AnomalyDetectorMapperTest {
     private AnomalyDetectorMapper mapper;
 
     // Test objects
-    private MetricData mpointWithDetectors;
-    private MetricData mpointWithoutDetectors;
+    private MetricData metricDataWithDetectors;
+    private MetricData metricDataWithoutDetectors;
 
     @Before
     public void setUp() {
@@ -53,7 +53,7 @@ public final class AnomalyDetectorMapperTest {
                     put("mtype", "dummy");
                     put("what", "bookings");
                 }}));
-        this.mpointWithDetectors = new MetricData(metricWithDetectors, 9, System.currentTimeMillis());
+        this.metricDataWithDetectors = new MetricData(metricWithDetectors, 9, System.currentTimeMillis());
 
         // TODO For now, this is known to have no detectors. See above.
         final MetricDefinition metricWithoutDetectors = new MetricDefinition(new TagCollection(
@@ -61,20 +61,20 @@ public final class AnomalyDetectorMapperTest {
                     put("unit", "dummy");
                     put("mtype", "dummy");
                 }}));
-        this.mpointWithoutDetectors = new MetricData(metricWithoutDetectors, 9, System.currentTimeMillis());
+        this.metricDataWithoutDetectors = new MetricData(metricWithoutDetectors, 9, System.currentTimeMillis());
     }
 
     @Test
     @Ignore
-    public void testMap_mpointWithDetectors() {
-        final Set<MappedMetricData> results = mapper.map(mpointWithDetectors);
+    public void testMap_metricDataWithDetectors() {
+        final Set<MappedMetricData> results = mapper.map(metricDataWithDetectors);
         assertFalse(results.isEmpty());
     }
 
     @Test
     @Ignore
-    public void testMap_mpointWithoutDetectors() {
-        final Set<MappedMetricData> results = mapper.map(mpointWithoutDetectors);
+    public void testMap_metricDataWithoutDetectors() {
+        final Set<MappedMetricData> results = mapper.map(metricDataWithoutDetectors);
         assertTrue(results.isEmpty());
     }
 }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/Metric.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/Metric.java
@@ -17,19 +17,22 @@ package com.expedia.adaptivealerting.modelservice.entity;
 
 import com.expedia.adaptivealerting.modelservice.util.JpaConverterJson;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import java.util.Map;
-
 
 @Data
 @Entity
-@NoArgsConstructor
 public class Metric {
+    
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
 
     @Column(name = "m_key")
     private String key;
@@ -38,10 +41,4 @@ public class Metric {
 
     @Convert(converter = JpaConverterJson.class)
     private Map<String, Object> tags;
-
-    public Metric(String key, String hash) {
-        this.key = key;
-        this.hash = hash;
-
-    }
 }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/MetricModelMapping.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/MetricModelMapping.java
@@ -7,9 +7,10 @@ import javax.persistence.*;
 @Data
 @Entity
 public class MetricModelMapping {
+    
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
 
     @ManyToOne
     @JoinColumn(name = "metric_id")

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/Model.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/Model.java
@@ -15,38 +15,51 @@
  */
 package com.expedia.adaptivealerting.modelservice.entity;
 
+import com.expedia.adaptivealerting.modelservice.util.JpaConverterJson;
 import lombok.Data;
 
-import javax.persistence.*;
-
-import com.expedia.adaptivealerting.modelservice.util.JpaConverterJson;
-import lombok.NoArgsConstructor;
-
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import java.sql.Timestamp;
 import java.util.Map;
 
 @Data
 @Entity
-@NoArgsConstructor
 public class Model {
+    
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
-
+    private Long id;
+    
     private String uuid;
-
+    
+    @ManyToOne
+    @JoinColumn(name = "type_id")
+    private ModelType type;
+    
     @Convert(converter = JpaConverterJson.class)
     private Map<String, Object> hyperparams;
-
-    @Column(name = "training_location")
+    
     private String trainingLocation;
-
+    
+    /**
+     * DB-driven weak sigma override for models that have this parameter. Allows us to make sensitivity adjustments in
+     * response to user feedback when ground truth classifications aren't available.
+     */
+    private double weakSigmas;
+    
+    /**
+     * DB-driven strong sigma override for models that have this parameter. Allows us to make sensitivity adjustments in
+     * response to user feedback when ground truth classifications aren't available.
+     */
+    private double strongSigmas;
+    
     @Column(name = "last_build_ts")
     private Timestamp buildTimestamp;
-
-    public Model(String uuid, Map<String, Object> hyperparams, String trainingLocation) {
-        this.uuid = uuid;
-        this.hyperparams = hyperparams;
-        this.trainingLocation = trainingLocation;
-    }
 }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/ModelType.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/ModelType.java
@@ -13,12 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.expedia.adaptivealerting.modelservice.dao;
+package com.expedia.adaptivealerting.modelservice.entity;
+
+import lombok.Data;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 
 /**
- * Model data access object.
+ * Model type.
  *
  * @author Willie Wheeler
  */
-public interface ModelDao {
+@Data
+@Entity
+public class ModelType {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    public String key;
 }

--- a/modelservice/src/main/sql/build-db.sql
+++ b/modelservice/src/main/sql/build-db.sql
@@ -1,10 +1,9 @@
 # -------------
-DROP DATABASE IF EXISTS model_service;
+DROP DATABASE IF EXISTS aa_model_service;
 
-create database model_service;
+create database aa_model_service;
 
-use model_service;
-
+use aa_model_service;
 
 create table metric
 (
@@ -14,25 +13,31 @@ create table metric
   tags      json
 );
 
+create table model_type
+(
+  id        smallint unsigned primary key not null auto_increment,
+  `key`     varchar(100) unique not null
+);
+
 create table model
 (
   id                  int unsigned primary key not null auto_increment,
-  uuid                varchar(100) unique not null,
+  uuid                char(36) unique not null,
+  type_id             smallint unsigned not null,
   hyperparams         json,
   training_location   varchar(300),
-  last_build_ts       timestamp
+  weak_sigmas         decimal(3, 3),
+  strong_sigmas       decimal(3, 3),
+  last_build_ts       timestamp,
+  constraint type_id_fk foreign key (type_id) references model_type (id)
 );
-
 
 create table metric_model_mapping
 (
   id         int unsigned primary key not null auto_increment,
   metric_id  int unsigned not null,
   model_id   int unsigned not null,
-  constraint metric_id_fk foreign key (metric_id) references metric (id)
-    on delete cascade
-    on update cascade,
-  constraint model_id_fk foreign key (model_id) references model (id)
-    on delete cascade
-    on update cascade
+  constraint metric_id_fk foreign key (metric_id) references metric (id),
+  constraint model_id_fk foreign key (model_id) references model (id),
+  unique index (metric_id, model_id)
 );

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/util/JpaConverterJsonTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/util/JpaConverterJsonTest.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 /**
  * @author kashah
  */
-public class JpaConverterJsonTests {
+public class JpaConverterJsonTest {
 
     /* Class under test */
     @InjectMocks

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/HealthControllerTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/HealthControllerTest.java
@@ -7,7 +7,7 @@ import org.mockito.MockitoAnnotations;
 
 import static junit.framework.TestCase.assertEquals;
 
-public class HealhControllerTests {
+public class HealthControllerTest {
 
     /* Class under test */
     @InjectMocks


### PR DESCRIPTION
- Fixed unit test class names
- Renamed "model_service" db to "aa_model_service" to clarify the app
- Added weak/strong sigma overrides to the model table to support dynamic
  adjustments
- Added model types
- Removed on delete/update cascades since Hibernate already manages this
  (and I believe expects to manage this)
- Set uuid column to 36 chars (32 alphanumeric + 4 dash)
- Added unique index on metric_model_mapping <metric, model> pairs