### PR TITLE
ADManager config bugfix

### DIFF
--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetectorFactory.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/AnomalyDetectorFactory.java
@@ -26,6 +26,13 @@ import java.util.UUID;
  */
 public interface AnomalyDetectorFactory<T extends AnomalyDetector> {
     
+    // FIXME Remove these hardcodes. We are planning to move the models into the DB so these will go away. [WLW]
+    @Deprecated
+    String REGION = "us-west-2";
+    
+    @Deprecated
+    String BUCKET = "aa-models";
+    
     /**
      * Initializes the factory.
      *

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/constant/ConstantThresholdFactory.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/constant/ConstantThresholdFactory.java
@@ -40,7 +40,6 @@ public final class ConstantThresholdFactory implements AnomalyDetectorFactory<Co
     // TODO Move this AWS-specific code out of this factory.
     // The actual param load code will go in modelservice-s3. [WLW]
     private AmazonS3 s3;
-    private String bucket;
     private String folder;
     
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -50,20 +49,12 @@ public final class ConstantThresholdFactory implements AnomalyDetectorFactory<Co
         notNull(type, "type can't be null");
         notNull(config, "config can't be null");
         
-        // TODO Reorganize the config here. We don't want every factory to have its own region and bucket. [WLW]
-        final String region = config.getString("region");
-        final String bucket = config.getString("bucket");
-    
-        notNull(region, "Property 'region' must be defined");
-        notNull(bucket, "Property 'bucket' must be defined");
-    
         this.s3 = AmazonS3ClientBuilder.standard()
-                .withRegion(region)
+                .withRegion(REGION)
                 .build();
-        this.bucket = bucket;
         this.folder = type;
     
-        log.info("Initialized ConstantThresholdFactory: region={}, bucket={}, folder={}", region, bucket, folder);
+        log.info("Initialized ConstantThresholdFactory: folder={}", folder);
     }
     
     @Override
@@ -71,7 +62,7 @@ public final class ConstantThresholdFactory implements AnomalyDetectorFactory<Co
         notNull(uuid, "uuid can't be null");
     
         final String path = folder + "/" + uuid.toString() + ".json";
-        final S3Object s3Obj = s3.getObject(bucket, path);
+        final S3Object s3Obj = s3.getObject(BUCKET, path);
         final InputStream is = s3Obj.getObjectContent();
     
         ConstantThresholdModel model;

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/cusum/CusumFactory.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/cusum/CusumFactory.java
@@ -40,7 +40,6 @@ public final class CusumFactory implements AnomalyDetectorFactory<CusumAnomalyDe
     // TODO Move this AWS-specific code out of this factory.
     // The actual param load code will go in modelservice-s3. [WLW]
     private AmazonS3 s3;
-    private String bucket;
     private String folder;
     
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -49,21 +48,13 @@ public final class CusumFactory implements AnomalyDetectorFactory<CusumAnomalyDe
     public void init(String type, Config config) {
         notNull(type, "type can't be null");
         notNull(config, "config can't be null");
-        
-        // TODO Reorganize the config here. We don't want every factory to have its own region and bucket. [WLW]
-        final String region = config.getString("region");
-        final String bucket = config.getString("bucket");
-    
-        notNull(region, "Property 'region' must be defined");
-        notNull(bucket, "Property 'bucket' must be defined");
     
         this.s3 = AmazonS3ClientBuilder.standard()
-                .withRegion(region)
+                .withRegion(REGION)
                 .build();
-        this.bucket = bucket;
         this.folder = type;
         
-        log.info("Initialized CusumFactory: region={}, bucket={}, folder={}", region, bucket, folder);
+        log.info("Initialized CusumFactory: folder={}", folder);
     }
     
     @Override
@@ -71,7 +62,7 @@ public final class CusumFactory implements AnomalyDetectorFactory<CusumAnomalyDe
         notNull(uuid, "uuid can't be null");
         
         final String path = folder + "/" + uuid.toString() + ".json";
-        final S3Object s3Obj = s3.getObject(bucket, path);
+        final S3Object s3Obj = s3.getObject(BUCKET, path);
         final InputStream is = s3Obj.getObjectContent();
         
         CusumModel model;

--- a/kafka/src/main/resources/config/base.conf
+++ b/kafka/src/main/resources/config/base.conf
@@ -28,7 +28,7 @@ ad-manager {
     default.timestamp.extractor = "com.expedia.adaptivealerting.kafka.serde.MappedMetricDataTimestampExtractor"
   }
   factories {
-    constant = "com.expedia.adaptivealerting.anomdetect.constant.ConstantThresholdFactory"
+    constant-detector = "com.expedia.adaptivealerting.anomdetect.constant.ConstantThresholdFactory"
     cusum-detector = "com.expedia.adaptivealerting.anomdetect.cusum.CusumFactory"
     ewma-detector = "com.expedia.adaptivealerting.anomdetect.ewma.EwmaFactory"
     pewma-detector = "com.expedia.adaptivealerting.anomdetect.pewma.PewmaFactory"


### PR DESCRIPTION
The ADManager config expected to see region and bucket params that don't
actually exist. Rather than adding these, I hardcoded the region and
bucket, because we plan to switch over to DB-based model storage very
shortly (in two weeks or so). When we do this, the region and bucket
params go away.